### PR TITLE
feat: virtual group init

### DIFF
--- a/tests/llama3_moe/test_dist.py
+++ b/tests/llama3_moe/test_dist.py
@@ -12,15 +12,15 @@ import torch.distributed as dist
 from dtest import DTest
 
 from torchtitan.components.checkpoint import CheckpointManager, ModelWrapper
-from torchtitan.distributed import ParallelDims, utils as dist_utils
+from torchtitan.distributed import ParallelDims
 from torchtitan.models.llama3_moe import (
     CustomCheckpointManager,
-    llama3_moe_configs,
     Llama3MoEStateDictAdapter,
-    parallelize_llama_moe,
-    ReplicateMoETransform,
     Transformer,
     TransformingHuggingFaceStorageReader,
+    get_hf_weight_transform_cls,
+    llama3_moe_configs,
+    parallelize_llama_moe,
 )
 from torchtitan.models.llama3_moe.custom_args import JobConfig
 
@@ -177,8 +177,115 @@ class TestHFReader(DTest):
             model = Transformer(model_args)
             model_moe = Transformer(model_args_moe)
 
-        dist_utils.rank_zero_print(f"{model=}")
-        dist_utils.rank_zero_print(f"{model_moe=}")
+        parallel_dims = ParallelDims(
+            dp_shard=-1,
+            dp_replicate=1,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=self.world_size if sharding == "ep" else 1,
+            etp=1,
+            world_size=self.world_size,
+        )
+
+        model = parallelize_llama_moe(model, parallel_dims, job_config)
+        model_moe = parallelize_llama_moe(model_moe, parallel_dims, job_config)
+
+        model.to_empty(device=self.device)
+        with torch.no_grad():
+            model.init_weights(buffer_device=None)
+
+        model_moe.to_empty(device=self.device)
+        with torch.no_grad():
+            model_moe.init_weights(buffer_device=None)
+
+        ckpt_kwargs = {
+            "dataloader": None,
+            "optimizers": None,  # HACK: @goon - ok to set to None for initial load
+            "lr_schedulers": None,  # HACK: @goon - ok to set to None for initial load
+            "states": {"train_state": self},
+            "checkpoint_config": job_config.checkpoint,
+            "base_folder": "",
+            "ft_manager": None,
+        }
+
+        checkpointer = CheckpointManager(
+            model_parts=[model],
+            sd_adapter=Llama3MoEStateDictAdapter(model_args, self.hf_assets_path),
+            **ckpt_kwargs,
+        )
+        checkpointer.load()
+
+        sd_adapter_moe = Llama3MoEStateDictAdapter(model_args_moe, self.hf_assets_path)
+        custom_checkpointer = CustomCheckpointManager(
+            hf_storage_reader=TransformingHuggingFaceStorageReader,
+            hf_storage_reader_kwargs={
+                "transform_fn": get_hf_weight_transform_cls("replicate")(
+                    model_args=model_args_moe,
+                    hf_to_titan_fqn_map=sd_adapter_moe.from_hf_map,
+                ),
+                "state_dict": ModelWrapper([model_moe]).state_dict(),
+                "sd_adapter": sd_adapter_moe,
+            },
+            model_parts=[model_moe],
+            sd_adapter=sd_adapter_moe,
+            **ckpt_kwargs,
+        )
+        custom_checkpointer.load()
+        with torch.no_grad():
+            # Verify weight correctness:
+            sd = model.state_dict()
+            sd_moe = model_moe.state_dict()
+            for k_moe in sd_moe:
+                if "moe" not in k_moe:
+                    w, w_moe = sd[k_moe].full_tensor(), sd_moe[k_moe].full_tensor()
+                    torch.testing.assert_close(w, w_moe)
+
+                elif "moe.experts" in k_moe:
+                    # Grab the MoE expert weights and the FFN weight they should have originated
+                    # from.
+                    k = k_moe.replace("moe.experts", "feed_forward") + ".weight"
+                    w, w_moe = sd[k].full_tensor(), sd_moe[k_moe].full_tensor()
+                    assert (
+                        torch.Size((model_args_moe.moe_args.num_experts,)) + w.shape
+                        == w_moe.shape
+                    ), f"{w.shape=}, {w_moe.shape=}"
+                    for w_moe_expert_shard in w_moe:
+                        torch.testing.assert_close(w, w_moe_expert_shard)
+
+
+class TestImpls(DTest):
+    hf_assets_path = "/gpfs/goon/models/Llama-3.2-3B-no-tied-weights/"
+    seqlen = 64
+    bsz = 1
+    atol = 1e-1
+    rtol = 1e-1
+    """
+    Test impl correctness
+    """
+
+    @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
+    def test_basic_replication(self, sharding: str) -> None:
+        """
+        Test that the dense and MoE models have the same output with FFN weight replication.
+        """
+        model_args = llama3_moe_configs["3B_2layer"]
+        model_args_moe = llama3_moe_configs["3B_2layer_halfmoe"]
+        job_config = JobConfig()
+        job_config.checkpoint.enable = True
+        job_config.checkpoint.initial_load_in_hf = True
+        job_config.model.hf_assets_path = self.hf_assets_path
+
+        moe_args = model_args_moe.moe_args
+        assert moe_args.score_func == "softmax"
+        assert moe_args.route_norm == True
+        assert moe_args.score_before_experts == False
+        assert model_args.custom_moe_impl is None
+        assert model_args_moe.custom_moe_impl is None
+
+        with torch.device("meta"):
+            model = Transformer(model_args)
+            model_moe = Transformer(model_args_moe)
 
         parallel_dims = ParallelDims(
             dp_shard=-1,
@@ -223,7 +330,7 @@ class TestHFReader(DTest):
         custom_checkpointer = CustomCheckpointManager(
             hf_storage_reader=TransformingHuggingFaceStorageReader,
             hf_storage_reader_kwargs={
-                "transform_fn": ReplicateMoETransform(
+                "transform_fn": get_hf_weight_transform_cls("replicate")(
                     model_args=model_args_moe,
                     hf_to_titan_fqn_map=sd_adapter_moe.from_hf_map,
                 ),
@@ -235,23 +342,99 @@ class TestHFReader(DTest):
             **ckpt_kwargs,
         )
         custom_checkpointer.load()
-        with torch.no_grad():
-            # Verify weight correctness:
-            sd = model.state_dict()
-            sd_moe = model_moe.state_dict()
-            for k_moe in sd_moe:
-                if "moe" not in k_moe:
-                    w, w_moe = sd[k_moe].full_tensor(), sd_moe[k_moe].full_tensor()
-                    torch.testing.assert_close(w, w_moe)
 
-                elif "moe.experts" in k_moe:
-                    # Grab the MoE expert weights and the FFN weight they should have originated
-                    # from.
-                    k = k_moe.replace("moe.experts", "feed_forward") + ".weight"
-                    w, w_moe = sd[k].full_tensor(), sd_moe[k_moe].full_tensor()
-                    assert (
-                        torch.Size((model_args_moe.moe_args.num_experts,)) + w.shape
-                        == w_moe.shape
-                    ), f"{w.shape=}, {w_moe.shape=}"
-                    for w_moe_expert_shard in w_moe:
-                        torch.testing.assert_close(w, w_moe_expert_shard)
+        with torch.no_grad():
+            inputs = torch.randint(
+                model_args.vocab_size, size=(self.bsz, self.seqlen), device=self.device
+            )
+            out = model(inputs)
+            out_moe = model_moe(inputs)
+            torch.testing.assert_close(out, out_moe, atol=self.atol, rtol=self.rtol)
+
+    @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
+    def test_finegrained_replication(self, sharding: str) -> None:
+        """
+        Test that the dense and MoE models have the same output with FFN weight replication.
+        """
+        model_args = llama3_moe_configs["3B_2layer"]
+        model_args_moe = llama3_moe_configs["3B_2layer_halfmoe_finegrained"]
+        job_config = JobConfig()
+        job_config.checkpoint.enable = True
+        job_config.checkpoint.initial_load_in_hf = True
+        job_config.model.hf_assets_path = self.hf_assets_path
+
+        moe_args = model_args_moe.moe_args
+        assert moe_args.score_func == "softmax"
+        assert moe_args.route_norm == True
+        assert moe_args.score_before_experts == False
+        assert moe_args.hf_ffn_hidden_dim is not None
+        assert model_args.custom_moe_impl is None
+        assert model_args_moe.custom_moe_impl == "replicated"
+
+        with torch.device("meta"):
+            model = Transformer(model_args)
+            model_moe = Transformer(model_args_moe)
+
+        parallel_dims = ParallelDims(
+            dp_shard=-1,
+            dp_replicate=1,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=self.world_size if sharding == "ep" else 1,
+            etp=1,
+            world_size=self.world_size,
+        )
+
+        model = parallelize_llama_moe(model, parallel_dims, job_config)
+        model_moe = parallelize_llama_moe(model_moe, parallel_dims, job_config)
+
+        model.to_empty(device=self.device)
+        with torch.no_grad():
+            model.init_weights(buffer_device=None)
+
+        model_moe.to_empty(device=self.device)
+        with torch.no_grad():
+            model_moe.init_weights(buffer_device=None)
+
+        ckpt_kwargs = {
+            "dataloader": None,
+            "optimizers": None,  # HACK: @goon - ok to set to None for initial load
+            "lr_schedulers": None,  # HACK: @goon - ok to set to None for initial load
+            "states": {"train_state": self},
+            "checkpoint_config": job_config.checkpoint,
+            "base_folder": "",
+            "ft_manager": None,
+        }
+
+        checkpointer = CheckpointManager(
+            model_parts=[model],
+            sd_adapter=Llama3MoEStateDictAdapter(model_args, self.hf_assets_path),
+            **ckpt_kwargs,
+        )
+        checkpointer.load()
+
+        sd_adapter_moe = Llama3MoEStateDictAdapter(model_args_moe, self.hf_assets_path)
+        custom_checkpointer = CustomCheckpointManager(
+            hf_storage_reader=TransformingHuggingFaceStorageReader,
+            hf_storage_reader_kwargs={
+                "transform_fn": get_hf_weight_transform_cls("replicate")(
+                    model_args=model_args_moe,
+                    hf_to_titan_fqn_map=sd_adapter_moe.from_hf_map,
+                ),
+                "state_dict": ModelWrapper([model_moe]).state_dict(),
+                "sd_adapter": sd_adapter_moe,
+            },
+            model_parts=[model_moe],
+            sd_adapter=sd_adapter_moe,
+            **ckpt_kwargs,
+        )
+        custom_checkpointer.load()
+
+        with torch.no_grad():
+            inputs = torch.randint(
+                model_args.vocab_size, size=(self.bsz, self.seqlen), device=self.device
+            )
+            out = model(inputs)
+            out_moe = model_moe(inputs)
+            torch.testing.assert_close(out, out_moe, atol=self.atol, rtol=self.rtol)

--- a/tests/llama3_moe/test_dist.py
+++ b/tests/llama3_moe/test_dist.py
@@ -93,7 +93,7 @@ class TestHFReader(DTest):
                 model_args.vocab_size, size=(self.bsz, self.seqlen), device=self.device
             )
             out = model(inputs)
-            out_copy = model(inputs)
+            out_copy = model_copy(inputs)
             torch.testing.assert_close(out, out_copy)
 
     @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
@@ -150,13 +150,14 @@ class TestHFReader(DTest):
         custom_checkpointer = CustomCheckpointManager(
             model_parts=[model_copy], **ckpt_kwargs
         )
+        custom_checkpointer.load()
         torch.manual_seed(42 + dist.get_rank())
         with torch.no_grad():
             inputs = torch.randint(
                 model_args.vocab_size, size=(self.bsz, self.seqlen), device=self.device
             )
             out = model(inputs)
-            out_copy = model(inputs)
+            out_copy = model_copy(inputs)
             torch.testing.assert_close(out, out_copy)
 
     @pytest.mark.parametrize("sharding", ["fsdp", "ep"])

--- a/tests/llama3_moe/test_model.py
+++ b/tests/llama3_moe/test_model.py
@@ -6,8 +6,7 @@
 
 import torch
 
-from torchtitan.models.llama3_moe.model.args import TransformerModelArgs
-from torchtitan.models.llama3_moe.model.model import Transformer
+from torchtitan.models.llama3_moe import Transformer, TransformerModelArgs
 
 
 class TestModel:

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -14,9 +14,9 @@ from torchtitan.models.llama3 import pipeline_llama
 from torchtitan.models.llama3_moe.checkpoint import CustomCheckpointManager
 from torchtitan.models.llama3_moe.custom_args import JobConfig
 from torchtitan.models.llama3_moe.hf_reader import (
-    get_hf_weight_transform_cls,
     ReplicateMoETransform,
     TransformingHuggingFaceStorageReader,
+    get_hf_weight_transform_cls,
 )
 from torchtitan.models.llama3_moe.infra.parallelize import parallelize_llama_moe
 from torchtitan.models.llama3_moe.model.args import TransformerModelArgs
@@ -163,9 +163,7 @@ llama3_moe_configs = {
         ),
         is_moe_list=[False, True],
     ),
-    # Requirements for virtual_group init:
-    # 1) moe_inter_dim * num_experts fixed to 8192 * 8
-    # 2) top_k a multiple of hf_ffn_hidden_dim / moe_inter_dim
+    # See VirtualGroupMoE for necessary cfg requirements for virtual_group init.
     "3B_2layer_halfmoe_finegrained": TransformerModelArgs(
         dim=3072,
         moe_inter_dim=8192 // 2,

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -158,8 +158,30 @@ llama3_moe_configs = {
             score_func="softmax",
             route_norm=True,
             score_before_experts=False,
+            top_k=2,
         ),
         is_moe_list=[False, True],
+    ),
+    "3B_2layer_halfmoe_finegrained": TransformerModelArgs(
+        dim=3072,
+        moe_inter_dim=8192,
+        n_layers=2,
+        n_heads=24,
+        n_kv_heads=8,
+        ffn_dim_multiplier=1.0,  # Correct?
+        multiple_of=256,
+        rope_theta=500000,
+        moe_args=MoEArgs(
+            num_experts=8,
+            num_shared_experts=0,
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
+            top_k=2,
+            hf_ffn_hidden_dim=8192,  # Must specify for replicated router init!
+        ),
+        is_moe_list=[False, True],
+        custom_moe_impl="replicated",  # Must specify for replicated router init!
     ),
     "8B": TransformerModelArgs(
         dim=4096,

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -50,7 +50,9 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=1,
             num_shared_experts=0,
-            score_func="softmax"
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
         ),
         is_moe_list=[True if n == 0 else False for n in range(6)],
     ),
@@ -63,7 +65,9 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=2,
             num_shared_experts=0,
-            score_func="softmax"
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
         ),
         is_moe_list=[True if n == 0 else False for n in range(6)],
     ),
@@ -76,7 +80,9 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=4,
             num_shared_experts=0,
-            score_func="softmax"
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
         ),
         is_moe_list=[True if n == 0 else False for n in range(6)],
     ),
@@ -89,7 +95,9 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=8,
             num_shared_experts=0,
-            score_func="softmax"
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
         ),
         is_moe_list=[True if n == 0 else False for n in range(6)],
     ),
@@ -102,7 +110,9 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=8,
             num_shared_experts=0,
-            score_func="softmax"
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
         ),
         is_moe_list=[True if n == 0 else False for n in range(6)],
     ),
@@ -143,7 +153,9 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=8,
             num_shared_experts=0,
-            score_func="softmax"
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
         ),
         is_moe_list=[False, True],
     ),
@@ -159,7 +171,9 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=2,
             num_shared_experts=0,
-            score_func="softmax"
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
         ),
         is_moe_list=None,
     ),
@@ -175,7 +189,9 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=2,
             num_shared_experts=0,
-            score_func="softmax"
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
         ),
     ),
     "8B_2exp_4_layer": TransformerModelArgs(
@@ -190,7 +206,9 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=2,
             num_shared_experts=0,
-            score_func="softmax"
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
         ),
     ),
     "8B_4exp": TransformerModelArgs(
@@ -205,7 +223,9 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=4,
             num_shared_experts=0,
-            score_func="softmax"
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
         ),
     ),
     "8B_8exp": TransformerModelArgs(
@@ -220,7 +240,9 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=8,
             num_shared_experts=0,
-            score_func="softmax"
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
         ),
     ),
     # can add other version from torchtitan/models/llama3/__init__.py

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -162,9 +162,12 @@ llama3_moe_configs = {
         ),
         is_moe_list=[False, True],
     ),
+    # Requirements for virtual_group init:
+    # 1) moe_inter_dim * num_experts fixed to 8192 * 8
+    # 2) top_k a multiple of hf_ffn_hidden_dim / moe_inter_dim
     "3B_2layer_halfmoe_finegrained": TransformerModelArgs(
         dim=3072,
-        moe_inter_dim=8192,
+        moe_inter_dim=8192 // 2,
         n_layers=2,
         n_heads=24,
         n_kv_heads=8,
@@ -172,16 +175,17 @@ llama3_moe_configs = {
         multiple_of=256,
         rope_theta=500000,
         moe_args=MoEArgs(
-            num_experts=8,
+            num_experts=8 * 2,
             num_shared_experts=0,
             score_func="softmax",
             route_norm=True,
             score_before_experts=False,
             top_k=2,
-            hf_ffn_hidden_dim=8192,  # Must specify for replicated router init!
+            route_scale=2,
+            hf_ffn_hidden_dim=8192,  # Must specify for virtual_group router init!
         ),
         is_moe_list=[False, True],
-        custom_moe_impl="replicated",  # Must specify for replicated router init!
+        custom_moe_impl="virtual_group",  # Must specify for virtual_group router init!
     ),
     "8B": TransformerModelArgs(
         dim=4096,

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -14,13 +14,13 @@ from torchtitan.models.llama3 import pipeline_llama
 from torchtitan.models.llama3_moe.checkpoint import CustomCheckpointManager
 from torchtitan.models.llama3_moe.custom_args import JobConfig
 from torchtitan.models.llama3_moe.hf_reader import (
+    get_hf_weight_transform_cls,
     ReplicateMoETransform,
     TransformingHuggingFaceStorageReader,
-    get_hf_weight_transform_cls,
 )
 from torchtitan.models.llama3_moe.infra.parallelize import parallelize_llama_moe
 from torchtitan.models.llama3_moe.model.args import TransformerModelArgs
-from torchtitan.models.llama3_moe.model.model import Transformer
+from torchtitan.models.llama3_moe.model.model import Transformer, VirtualGroupMoE
 from torchtitan.models.llama3_moe.model.state_dict_adapter import (
     Llama3MoEStateDictAdapter,
 )
@@ -35,6 +35,7 @@ __all__ = [
     "Transformer",
     "TransformerModelArgs",
     "TransformingHuggingFaceStorageReader",
+    "VirtualGroupMoE",
     "get_hf_weight_transform_cls",
     "llama3_configs",
     "parallelize_llama_moe",
@@ -181,7 +182,7 @@ llama3_moe_configs = {
             route_norm=True,
             score_before_experts=False,
             top_k=2,
-            route_scale=2, # Must have route_scale = top_k; see [Virtual Group Initialization].
+            route_scale=2,  # Must have route_scale = top_k; see [Virtual Group Initialization].
             hf_ffn_hidden_dim=8192,  # Must specify for virtual_group router init!
         ),
         is_moe_list=[False, True],

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -50,6 +50,7 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=1,
             num_shared_experts=0,
+            score_func="softmax"
         ),
         is_moe_list=[True if n == 0 else False for n in range(6)],
     ),
@@ -62,6 +63,7 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=2,
             num_shared_experts=0,
+            score_func="softmax"
         ),
         is_moe_list=[True if n == 0 else False for n in range(6)],
     ),
@@ -74,6 +76,7 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=4,
             num_shared_experts=0,
+            score_func="softmax"
         ),
         is_moe_list=[True if n == 0 else False for n in range(6)],
     ),
@@ -86,6 +89,7 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=8,
             num_shared_experts=0,
+            score_func="softmax"
         ),
         is_moe_list=[True if n == 0 else False for n in range(6)],
     ),
@@ -98,6 +102,7 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=8,
             num_shared_experts=0,
+            score_func="softmax"
         ),
         is_moe_list=[True if n == 0 else False for n in range(6)],
     ),
@@ -138,6 +143,7 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=8,
             num_shared_experts=0,
+            score_func="softmax"
         ),
         is_moe_list=[False, True],
     ),
@@ -153,6 +159,7 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=2,
             num_shared_experts=0,
+            score_func="softmax"
         ),
         is_moe_list=None,
     ),
@@ -168,6 +175,7 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=2,
             num_shared_experts=0,
+            score_func="softmax"
         ),
     ),
     "8B_2exp_4_layer": TransformerModelArgs(
@@ -182,6 +190,7 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=2,
             num_shared_experts=0,
+            score_func="softmax"
         ),
     ),
     "8B_4exp": TransformerModelArgs(
@@ -196,6 +205,7 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=4,
             num_shared_experts=0,
+            score_func="softmax"
         ),
     ),
     "8B_8exp": TransformerModelArgs(
@@ -210,6 +220,7 @@ llama3_moe_configs = {
         moe_args=MoEArgs(
             num_experts=8,
             num_shared_experts=0,
+            score_func="softmax"
         ),
     ),
     # can add other version from torchtitan/models/llama3/__init__.py

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -16,6 +16,7 @@ from torchtitan.models.llama3_moe.custom_args import JobConfig
 from torchtitan.models.llama3_moe.hf_reader import (
     ReplicateMoETransform,
     TransformingHuggingFaceStorageReader,
+    get_hf_weight_transform_cls,
 )
 from torchtitan.models.llama3_moe.infra.parallelize import parallelize_llama_moe
 from torchtitan.models.llama3_moe.model.args import TransformerModelArgs
@@ -34,6 +35,7 @@ __all__ = [
     "Transformer",
     "TransformerModelArgs",
     "TransformingHuggingFaceStorageReader",
+    "get_hf_weight_transform_cls",
     "llama3_configs",
     "parallelize_llama_moe",
     "pipeline_llama",

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -181,7 +181,7 @@ llama3_moe_configs = {
             route_norm=True,
             score_before_experts=False,
             top_k=2,
-            route_scale=2,
+            route_scale=2, # Must have route_scale = top_k; see [Virtual Group Initialization].
             hf_ffn_hidden_dim=8192,  # Must specify for virtual_group router init!
         ),
         is_moe_list=[False, True],

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -14,9 +14,9 @@ from torchtitan.models.llama3 import pipeline_llama
 from torchtitan.models.llama3_moe.checkpoint import CustomCheckpointManager
 from torchtitan.models.llama3_moe.custom_args import JobConfig
 from torchtitan.models.llama3_moe.hf_reader import (
+    get_hf_weight_transform_cls,
     ReplicateMoETransform,
     TransformingHuggingFaceStorageReader,
-    get_hf_weight_transform_cls,
 )
 from torchtitan.models.llama3_moe.infra.parallelize import parallelize_llama_moe
 from torchtitan.models.llama3_moe.model.args import TransformerModelArgs

--- a/torchtitan/models/llama3_moe/checkpoint.py
+++ b/torchtitan/models/llama3_moe/checkpoint.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Type
+from typing import Any
 
 import torch.distributed.checkpoint as dcp
 from torch.distributed.checkpoint import HuggingFaceStorageReader
@@ -22,7 +22,7 @@ TRAIN_STATE = "train_state"
 class CustomCheckpointManager(CheckpointManager):
     def __init__(
         self,
-        hf_storage_reader: Type[HuggingFaceStorageReader] = HuggingFaceStorageReader,
+        hf_storage_reader: type[HuggingFaceStorageReader] = HuggingFaceStorageReader,
         hf_storage_reader_kwargs: dict[str, Any] | None = None,
         *args,
         **kwargs,
@@ -49,9 +49,9 @@ class CustomCheckpointManager(CheckpointManager):
         """
 
         if from_hf:
-            assert (
-                self.sd_adapter is not None
-            ), "trying to load checkpoint in HF safetensors format, but sd_adapter is not provided."
+            assert self.sd_adapter is not None, (
+                "trying to load checkpoint in HF safetensors format, but sd_adapter is not provided."
+            )
             hf_state_dict = self.sd_adapter.to_hf(state_dict)
 
             # TODO: @goon - DELETE

--- a/torchtitan/models/llama3_moe/checkpoint.py
+++ b/torchtitan/models/llama3_moe/checkpoint.py
@@ -53,8 +53,6 @@ class CustomCheckpointManager(CheckpointManager):
                 self.sd_adapter is not None
             ), "trying to load checkpoint in HF safetensors format, but sd_adapter is not provided."
             hf_state_dict = self.sd_adapter.to_hf(state_dict)
-            for k, v in hf_state_dict.items():
-                dist_utils.rank_zero_print(f"{k=}: {v.shape=}")
 
             # TODO: @goon - DELETE
             dist_utils.rank_zero_print(

--- a/torchtitan/models/llama3_moe/checkpoint.py
+++ b/torchtitan/models/llama3_moe/checkpoint.py
@@ -49,9 +49,9 @@ class CustomCheckpointManager(CheckpointManager):
         """
 
         if from_hf:
-            assert self.sd_adapter is not None, (
-                "trying to load checkpoint in HF safetensors format, but sd_adapter is not provided."
-            )
+            assert (
+                self.sd_adapter is not None
+            ), "trying to load checkpoint in HF safetensors format, but sd_adapter is not provided."
             hf_state_dict = self.sd_adapter.to_hf(state_dict)
 
             # TODO: @goon - DELETE

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -12,6 +12,7 @@ from torchtitan.config.job_config import JobConfig
 @dataclass
 class CustomArgs:
     load_balance_coeff: float | None = None
+    hf_weight_transform: str = "replicate"
 
 
 @dataclass

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -13,7 +13,7 @@ from torchtitan.config.job_config import JobConfig
 class CustomArgs:
     load_balance_coeff: float | None = None
     hf_weight_transform: str = "replicate"
-    hf_ffn_hidden_dim: int | None = None 
+    hf_ffn_hidden_dim: int | None = None
 
 
 @dataclass

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -13,6 +13,7 @@ from torchtitan.config.job_config import JobConfig
 class CustomArgs:
     load_balance_coeff: float | None = None
     hf_weight_transform: str = "replicate"
+    hf_ffn_hidden_dim: int | None = None 
 
 
 @dataclass

--- a/torchtitan/models/llama3_moe/hf_reader.py
+++ b/torchtitan/models/llama3_moe/hf_reader.py
@@ -13,10 +13,10 @@ import torch
 from einops import rearrange
 from torch.distributed.checkpoint import HuggingFaceStorageReader
 from torch.distributed.checkpoint._hf_utils import (
+    _HFStorageInfo,
     CUSTOM_METADATA_KEY,
     SAVED_OFFSETS_KEY,
     SUFFIX,
-    _HFStorageInfo,
 )
 from torch.distributed.checkpoint.metadata import (
     ChunkStorageMetadata,
@@ -192,7 +192,8 @@ class _HFWeightTransform(ABC):
         return self.transform(titan_fqn, t)
 
     @abstractmethod
-    def transform(self, titan_fqn: str, t: torch.Tensor) -> torch.Tensor: ...
+    def transform(self, titan_fqn: str, t: torch.Tensor) -> torch.Tensor:
+        ...
 
 
 class ReplicateMoETransform(_HFWeightTransform):

--- a/torchtitan/models/llama3_moe/model/args.py
+++ b/torchtitan/models/llama3_moe/model/args.py
@@ -72,14 +72,6 @@ class TransformerModelArgs(BaseModelArgs):
             self.moe_args.load_balance_coeff = job_config.custom_args.load_balance_coeff
 
         if job_config.custom_args.hf_ffn_hidden_dim is not None:
-            if (
-                self.moe_args.num_experts
-                * self.moe_inter_dim
-                % job_config.custom_args.hf_ffn_hidden_dim
-            ):
-                raise ValueError(
-                    f"{self.moe_args.num_experts *self.moe_inter_dim=} must be divisible by {job_config.custom_args.hf_ffn_hidden_dim=}"
-                )
             self.moe_args.hf_ffn_hidden_dim = job_config.custom_args.hf_ffn_hidden_dim
 
         if self.is_moe_list is not None and len(self.is_moe_list) != self.n_layers:

--- a/torchtitan/models/llama3_moe/model/model.py
+++ b/torchtitan/models/llama3_moe/model/model.py
@@ -276,7 +276,6 @@ class VirtualGroupMoE(_CustomMoE):
     the above can be achieved by initializing the weight P_ed = P_rgd so that it is independent of
     g, i.e. P_rgd = Q_rd for some Q_rd, and also taking the k in top_k to be a multiple of G so that
     entire groups are activated together. The same conclusion also holds for softmax-then-top_k.
-
     """
 
     name = "virtual_group"

--- a/torchtitan/models/llama3_moe/model/state_dict_adapter.py
+++ b/torchtitan/models/llama3_moe/model/state_dict_adapter.py
@@ -58,9 +58,9 @@ class Llama3MoEStateDictAdapter(StateDictAdapter):
             self.from_hf_map[
                 f"model.layers.{layer_idx}.self_attn.rotary_emb.inv_freq"
             ] = None
-            self.from_hf_map[f"model.layers.{layer_idx}.input_layernorm.weight"] = (
-                f"layers.{layer_idx}.attention_norm.weight"
-            )
+            self.from_hf_map[
+                f"model.layers.{layer_idx}.input_layernorm.weight"
+            ] = f"layers.{layer_idx}.attention_norm.weight"
             self.from_hf_map[
                 f"model.layers.{layer_idx}.post_attention_layernorm.weight"
             ] = f"layers.{layer_idx}.ffn_norm.weight"
@@ -70,14 +70,14 @@ class Llama3MoEStateDictAdapter(StateDictAdapter):
                 ] = f"layers.{layer_idx}.attention.{titan_name}.weight"
             if is_moe:
                 for hf_name, titan_name in moe_name_weight_map.items():
-                    self.from_hf_map[f"model.layers.{layer_idx}.{hf_name}.weight"] = (
-                        f"layers.{layer_idx}.{titan_name}"
-                    )
+                    self.from_hf_map[
+                        f"model.layers.{layer_idx}.{hf_name}.weight"
+                    ] = f"layers.{layer_idx}.{titan_name}"
             else:
                 for hf_name, titan_name in ffn_name_weight_map.items():
-                    self.from_hf_map[f"model.layers.{layer_idx}.{hf_name}.weight"] = (
-                        f"layers.{layer_idx}.{titan_name}.weight"
-                    )
+                    self.from_hf_map[
+                        f"model.layers.{layer_idx}.{hf_name}.weight"
+                    ] = f"layers.{layer_idx}.{titan_name}.weight"
             dist_utils.rank_zero_print(f"{self.from_hf_map=}")
 
     # HuggingFace permutation function (exact copy from their conversion script)

--- a/torchtitan/models/llama3_moe/model/state_dict_adapter.py
+++ b/torchtitan/models/llama3_moe/model/state_dict_adapter.py
@@ -8,6 +8,8 @@ import logging
 from typing import Any
 from warnings import warn
 
+import torch.distributed as dist
+
 from torchtitan.distributed import utils as dist_utils
 from torchtitan.models.llama3_moe.model.args import TransformerModelArgs
 from torchtitan.protocols.state_dict_adapter import StateDictAdapter
@@ -56,9 +58,9 @@ class Llama3MoEStateDictAdapter(StateDictAdapter):
             self.from_hf_map[
                 f"model.layers.{layer_idx}.self_attn.rotary_emb.inv_freq"
             ] = None
-            self.from_hf_map[
-                f"model.layers.{layer_idx}.input_layernorm.weight"
-            ] = f"layers.{layer_idx}.attention_norm.weight"
+            self.from_hf_map[f"model.layers.{layer_idx}.input_layernorm.weight"] = (
+                f"layers.{layer_idx}.attention_norm.weight"
+            )
             self.from_hf_map[
                 f"model.layers.{layer_idx}.post_attention_layernorm.weight"
             ] = f"layers.{layer_idx}.ffn_norm.weight"
@@ -68,14 +70,14 @@ class Llama3MoEStateDictAdapter(StateDictAdapter):
                 ] = f"layers.{layer_idx}.attention.{titan_name}.weight"
             if is_moe:
                 for hf_name, titan_name in moe_name_weight_map.items():
-                    self.from_hf_map[
-                        f"model.layers.{layer_idx}.{hf_name}.weight"
-                    ] = f"layers.{layer_idx}.{titan_name}"
+                    self.from_hf_map[f"model.layers.{layer_idx}.{hf_name}.weight"] = (
+                        f"layers.{layer_idx}.{titan_name}"
+                    )
             else:
                 for hf_name, titan_name in ffn_name_weight_map.items():
-                    self.from_hf_map[
-                        f"model.layers.{layer_idx}.{hf_name}.weight"
-                    ] = f"layers.{layer_idx}.{titan_name}.weight"
+                    self.from_hf_map[f"model.layers.{layer_idx}.{hf_name}.weight"] = (
+                        f"layers.{layer_idx}.{titan_name}.weight"
+                    )
             dist_utils.rank_zero_print(f"{self.from_hf_map=}")
 
     # HuggingFace permutation function (exact copy from their conversion script)
@@ -108,7 +110,8 @@ class Llama3MoEStateDictAdapter(StateDictAdapter):
         conventions, possibly also changing tensor layouts, if necessary.
 
         Only used when loading from or saving to an HF ckpt (dcp_load,{save}) and in a conversion
-        utility script.
+        utility script. NOTE: @goon - we will need separate versions of this function for weight
+        loading and HF ckpt saving at some point.
         """
         to_hf_map = {v: k for k, v in self.from_hf_map.items()}
 
@@ -128,7 +131,9 @@ class Llama3MoEStateDictAdapter(StateDictAdapter):
                 # model's weights, e.g. if testing out with fewer layers than actually exist in the
                 # real model.
                 if key not in to_hf_map:
-                    warn(f"{key=} not found in {list(to_hf_map)=}. Skipping.")
+                    warn(
+                        f"[rank={dist.get_rank()}]: {key=} not found in {list(to_hf_map)=}. Skipping."
+                    )
                     continue
                 else:
                     new_key = to_hf_map[key]

--- a/torchtitan/models/moe.py
+++ b/torchtitan/models/moe.py
@@ -33,6 +33,11 @@ class MoEArgs:
     _debug_force_load_balance: bool = False
     # if True, we force each experts get same amount of token via round-robin
 
+    # NOTE: @goon - custom attrs
+    # Knowing the HF FFN hidden dim size is required for proper token router init with some
+    # strategies
+    hf_ffn_hidden_dim: int | None = None
+
 
 # can be used as dense FFN layer or shared experts in MoE layers
 class FeedForward(nn.Module):

--- a/torchtitan/models/moe.py
+++ b/torchtitan/models/moe.py
@@ -16,7 +16,7 @@ from torchtitan.distributed.expert_parallel import expert_parallel
 
 @dataclass
 class MoEArgs:
-    num_experts: int = 1
+    num_experts: int = 8
     num_shared_experts: int = 1
 
     # router
@@ -444,13 +444,6 @@ class MoE(nn.Module):
                 * top_scores_experts_sorted.reshape(-1, 1)
             ).to(x.dtype)
 
-        # if torch.distributed.get_rank() == 0:
-        #     breakpoint()
-        #     routed_output = self.experts(routed_input, num_tokens_per_expert)
-
-        # torch.distributed.barrier()
-
-        # shape (bs*slen*top_k, dim)
         routed_output = self.experts(routed_input, num_tokens_per_expert)
 
         # shared expert

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -22,15 +22,14 @@ from torchtitan.components.metrics import (
     build_metrics_processor,
     ensure_pp_loss_visible,
 )
-from torchtitan.config import TORCH_DTYPE_MAP, ConfigManager
-from torchtitan.distributed import ParallelDims
-from torchtitan.distributed import utils as dist_utils
+from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
+from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.models.attention import init_attention_mask
 from torchtitan.models.llama3_moe import (
     CustomCheckpointManager,
+    get_hf_weight_transform_cls,
     JobConfig,
     TransformingHuggingFaceStorageReader,
-    get_hf_weight_transform_cls,
 )
 from torchtitan.protocols.model_converter import build_model_converters
 from torchtitan.tools import utils
@@ -623,8 +622,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 )
 
                 # Run validation if validator is available
-                if self.job_config.validation.enable and self.validator.should_validate(
-                    self.step
+                if (
+                    self.job_config.validation.enable
+                    and self.validator.should_validate(self.step)
                 ):
                     with self.loss_fn.no_rescale():
                         self.validator.validate(self.model_parts, self.step)
@@ -682,12 +682,12 @@ if __name__ == "__main__":
         trainer = Trainer(config)
 
         if config.checkpoint.create_seed_checkpoint:
-            assert int(os.environ["WORLD_SIZE"]) == 1, (
-                "Must create seed checkpoint using a single device, to disable sharding."
-            )
-            assert config.checkpoint.enable, (
-                "Must enable checkpointing when creating a seed checkpoint."
-            )
+            assert (
+                int(os.environ["WORLD_SIZE"]) == 1
+            ), "Must create seed checkpoint using a single device, to disable sharding."
+            assert (
+                config.checkpoint.enable
+            ), "Must enable checkpointing when creating a seed checkpoint."
             trainer.checkpointer.save(curr_step=0, last_step=True)
             logger.info("Created seed checkpoint")
         else:


### PR DESCRIPTION
E2E tested virtual group init, as in [2410.07524](https://arxiv.org/abs/2410.07524). 

Also fixes some previous errors in distributed tests, and adds a FFN-MoE equivalence test for basic replicated init models, and undoes some minor, previous edits to `moe.py`.