### PR TITLE
feat: custom metrics

### DIFF
--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -407,6 +407,7 @@ def build_optimizers_with_moe_load_balancing(
                     expert_bias_delta = expert_bias_delta - expert_bias_delta.mean()
                     moe.expert_bias.add_(expert_bias_delta)
                     moe.tokens_per_expert.zero_()
+                    moe.tokens_per_expert_cumulative.add_(tokens_per_expert)
 
     if _should_register_moe_balancing_hook(model_parts):
         optimizers.register_step_pre_hook(

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -19,6 +19,10 @@ from torchtitan.models.llama3_moe.hf_reader import (
     TransformingHuggingFaceStorageReader,
 )
 from torchtitan.models.llama3_moe.infra.parallelize import parallelize_llama_moe
+from torchtitan.models.llama3_moe.metrics import (
+    build_custom_metrics_processor,
+    CustomMetricsProcessor,
+)
 from torchtitan.models.llama3_moe.model.args import TransformerModelArgs
 from torchtitan.models.llama3_moe.model.model import Transformer, VirtualGroupMoE
 from torchtitan.models.llama3_moe.model.state_dict_adapter import (
@@ -29,6 +33,7 @@ from torchtitan.protocols.train_spec import TrainSpec
 
 __all__ = [
     "CustomCheckpointManager",
+    "CustomMetricsProcessor",
     "JobConfig",
     "Llama3MoEStateDictAdapter",
     "ReplicateMoETransform",
@@ -36,6 +41,7 @@ __all__ = [
     "TransformerModelArgs",
     "TransformingHuggingFaceStorageReader",
     "VirtualGroupMoE",
+    "build_custom_metrics_processor",
     "get_hf_weight_transform_cls",
     "llama3_configs",
     "parallelize_llama_moe",
@@ -272,7 +278,6 @@ llama3_moe_configs = {
             score_before_experts=False,
         ),
     ),
-    # can add other version from torchtitan/models/llama3/__init__.py
 }
 
 
@@ -290,4 +295,5 @@ def get_train_spec() -> TrainSpec:
         build_loss_fn=build_cross_entropy_loss,
         build_validator_fn=build_validator,
         state_dict_adapter=Llama3MoEStateDictAdapter,
+        build_metrics_processor_fn=build_custom_metrics_processor,
     )

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -6,14 +6,14 @@
 
 import math
 from functools import cache, cached_property
-from typing import TYPE_CHECKING, Any
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.distributed as dist
 import torch.distributed._functional_collectives as funcol
 import torch.distributed.distributed_c10d as c10d
 
-from torchtitan.components.metrics import MetricsProcessor, _get_metrics_rank
+from torchtitan.components.metrics import _get_metrics_rank, MetricsProcessor
 from torchtitan.config import JobConfig
 from torchtitan.distributed import ParallelDims
 
@@ -238,9 +238,9 @@ class CustomMetricsProcessor(MetricsProcessor):
             for metric_name, metric_val in zip(
                 mem_stat_prefixes, mem_t.tolist(), strict=True
             ):
-                pp_mem_metrics[metric_name + f" pp mesh rank {pp_mesh_rank}"] = (
-                    metric_val
-                )
+                pp_mem_metrics[
+                    metric_name + f" pp mesh rank {pp_mesh_rank}"
+                ] = metric_val
         return pp_mem_metrics
 
     def log(

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -1,0 +1,283 @@
+import math
+from functools import cache, cached_property
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.distributed as dist
+import torch.distributed._functional_collectives as funcol
+import torch.distributed.distributed_c10d as c10d
+
+from torchtitan.components.metrics import MetricsProcessor, _get_metrics_rank
+from torchtitan.config import JobConfig
+from torchtitan.distributed import ParallelDims
+
+if TYPE_CHECKING:
+    from torchtitan.protocols import BaseModelArgs
+
+
+class CustomMetricsProcessor(MetricsProcessor):
+    eps = 1e-5
+    device = "cuda"
+    max_entropy: float | None = None
+
+    @cached_property
+    def rank(self) -> int:
+        return dist.get_rank()
+
+    @cached_property
+    def metrics_rank(self) -> int:
+        return _get_metrics_rank(self.parallel_dims, self.job_config)
+
+    @cached_property
+    def moe_layer_idxs(self) -> list[int]:
+        """
+        The MoE layer idxs on the present rank.
+        """
+        moe_layer_idxs = []
+        for model_part in self.model_parts:
+            for block_idx, transformer_block in model_part.layers.items():
+                if transformer_block.moe_enabled:
+                    moe_layer_idxs.append(int(block_idx))
+        return moe_layer_idxs
+
+    def send_tensor_to_metrics_rank(
+        self, rank: int, tensor: torch.Tensor
+    ) -> torch.Tensor | None:
+        """
+        Send the given tensor from rank to the metrics_rank process. metrics_rank passes in its
+        receive buffer. The recv buffer will be modified in-place, and a copy returned.
+        """
+        if self.rank not in (rank, self.metrics_rank):
+            return None
+
+        ops = []
+        if rank == self.rank:
+            ops.append(dist.P2POp(dist.isend, tensor, self.metrics_rank))
+        else:
+            ops.append(dist.P2POp(dist.irecv, tensor, rank))
+        for op in dist.batch_isend_irecv(ops):
+            op.wait()
+
+        if self.rank == self.metrics_rank:
+            return tensor.detach().clone()
+        return None
+
+    @cache
+    def send_moe_layer_idxs_to_metrics_rank(self, rank: int) -> list[int] | None:
+        """
+        Send MoE layer idxs on `rank` to the metrics rank. Returns the list of idxs on the metric
+        rank, and None on all others.
+
+        Two steps:
+        1. Send the number of idxs to expect
+        2. Send the idxs
+        """
+        if self.rank not in (rank, self.metrics_rank):
+            return None
+
+        # Send num idxs to expect
+        num_results = (
+            torch.tensor(
+                [len(self.moe_layer_idxs)], device=self.device, dtype=torch.int32
+            )
+            if rank == self.rank
+            else torch.empty(1, device=self.device, dtype=torch.int32)
+        )
+        num_results = self.send_tensor_to_metrics_rank(rank, num_results)
+
+        # Send idxs
+        layer_idxs = (
+            torch.tensor(self.moe_layer_idxs, device=self.device, dtype=torch.int32)
+            if rank == self.rank
+            else torch.empty(
+                int(num_results.item()), device=self.device, dtype=torch.int32
+            )
+        )
+        layer_idxs = self.send_tensor_to_metrics_rank(rank, layer_idxs)
+        if self.rank == self.metrics_rank:
+            return layer_idxs.tolist()
+        return None
+
+    def get_moe_balancing_metrics(self) -> dict[str, Any]:
+        pp_ranks = (
+            self.parallel_dims.world_mesh["pp"].mesh.tolist()
+            if self.parallel_dims.pp_enabled
+            else []
+        )
+        # Early return for irrelevant ranks. MoE optimizer code has already reduced tok counts
+        # across the dp_cp dim.
+        if self.rank != self.metrics_rank and self.metrics_rank not in pp_ranks:
+            return {}
+
+        moe_metrics = {}
+        # Get locally-available MoE stats on relevant ranks
+        for model_part in self.model_parts:
+            for block_idx, transformer_block in model_part.layers.items():
+                if not transformer_block.moe_enabled:
+                    continue
+                if transformer_block.moe.load_balance_coeff is None:
+                    return
+                tokens_per_expert_cumulative = (
+                    transformer_block.moe.tokens_per_expert_cumulative
+                )
+
+                tokens_per_expert_cumulative_prob = (
+                    tokens_per_expert_cumulative + self.eps
+                ) / (tokens_per_expert_cumulative + self.eps).sum()
+                entropy = (
+                    -tokens_per_expert_cumulative_prob.log()
+                    * tokens_per_expert_cumulative_prob
+                ).sum()
+                self.max_entropy = self.max_entropy or math.log(
+                    tokens_per_expert_cumulative_prob.numel()
+                )
+                moe_metrics[int(block_idx)] = entropy / self.max_entropy
+                transformer_block.moe.tokens_per_expert_cumulative.zero_()
+
+        # If using PP, need to also gather stats from other PP ranks.
+        for send_rank in pp_ranks:
+            if send_rank == self.metrics_rank:
+                continue
+            if self.rank in (send_rank, self.metrics_rank):
+                # Send/get cached moe idxs from send_rank
+                send_rank_idxs = self.send_moe_layer_idxs_to_metrics_rank(send_rank)
+                # Send results
+                results = (
+                    torch.stack(list(moe_metrics.values()), dim=-1)
+                    if send_rank == self.rank
+                    else torch.empty(
+                        len(send_rank_idxs),
+                        device=self.device,
+                    )
+                )
+                results = self.send_tensor_to_metrics_rank(send_rank, results)
+
+                if self.rank == self.metrics_rank:
+                    for idx, res in zip(send_rank_idxs, results, strict=True):
+                        moe_metrics[idx] = res
+
+        if self.rank != self.metrics_rank:
+            return {}
+        return {
+            f"moe/layer_{block_idx} moe normalized entropy": e.item()
+            for block_idx, e in moe_metrics.items()
+        }
+
+    def get_pp_memory_metrics(self) -> dict[str, Any]:
+        """
+        Get the CUDA memory metrics on each PP rank, max-reduced over the dp_cp group, if it exists.
+        """
+        if not self.parallel_dims.pp_enabled:
+            return {}
+
+        device_mem_stats = self.device_memory_monitor.get_peak_stats()
+        # Put mem stats in a tensor. Order
+        # 0: "memory/max_active(GiB)": device_mem_stats.max_active_gib,
+        # 1: "memory/max_active(%)": device_mem_stats.max_active_pct,
+        # 2: "memory/max_reserved(GiB)": device_mem_stats.max_reserved_gib,
+        # 3: "memory/max_reserved(%)": device_mem_stats.max_reserved_pct,
+        # 4: "memory/num_alloc_retries": device_mem_stats.num_alloc_retries,
+        # 5: "memory/num_ooms": device_mem_stats.num_ooms,
+        mem_stat_prefixes = [
+            "memory/max_active(GiB)",
+            "memory/max_active(%)",
+            "memory/max_reserved(GiB)",
+            "memory/max_reserved(%)",
+            "memory/num_alloc_retries",
+            "memory/num_ooms",
+        ]
+        mem_stats_t = torch.tensor(
+            [
+                device_mem_stats.max_active_gib,
+                device_mem_stats.max_active_pct,
+                device_mem_stats.max_reserved_gib,
+                device_mem_stats.max_reserved_pct,
+                device_mem_stats.num_alloc_retries,
+                device_mem_stats.num_ooms,
+            ],
+            dtype=torch.float32,
+            device=self.device,
+        )
+        if self.rank == self.metrics_rank:
+            recv_mem_stats_buffer_t = mem_stats_t.clone()
+
+        if self.parallel_dims.dp_cp_enabled:
+            mem_stats_t = funcol.all_reduce(
+                mem_stats_t,
+                reduceOp=c10d.ReduceOp.MAX.name,
+                group=self.parallel_dims.world_mesh["dp_cp"],
+            )
+
+        pp_ranks = self.parallel_dims.world_mesh["pp"].mesh.tolist()
+        # Only other members of the metrics rank's PP group need to send info. Early return for
+        # irrelevant ranks.
+        if self.metrics_rank not in pp_ranks:
+            return {}
+
+        # Use the enumerated idx of the rank as the PP rank (e.g. we use the mesh-local-rank)
+        pp_mem_metrics_t = {}
+        for pp_mesh_rank, send_rank in enumerate(pp_ranks):
+            if send_rank == self.metrics_rank:
+                pp_mem_metrics_t[pp_mesh_rank] = mem_stats_t
+                continue
+            if self.rank in (send_rank, self.metrics_rank):
+                recv_mem_stats_t = self.send_tensor_to_metrics_rank(
+                    send_rank,
+                    mem_stats_t if self.rank == send_rank else recv_mem_stats_buffer_t,
+                )
+                pp_mem_metrics_t[pp_mesh_rank] = recv_mem_stats_t
+        if self.rank != self.metrics_rank:
+            return {}
+        # Turn the tensorial mem metrics into nicely formatted ones
+        pp_mem_metrics = {}
+        for pp_mesh_rank, mem_t in pp_mem_metrics_t.items():
+            for metric_name, metric_val in zip(
+                mem_stat_prefixes, mem_t.tolist(), strict=True
+            ):
+                pp_mem_metrics[metric_name + f" pp mesh rank {pp_mesh_rank}"] = (
+                    metric_val
+                )
+        return pp_mem_metrics
+
+    def log(
+        self,
+        step: int,
+        global_avg_loss: float,
+        global_max_loss: float,
+        grad_norm: float,
+        extra_metrics: dict[str, Any] | None = None,
+    ) -> None:
+        moe_metrics = self.get_moe_balancing_metrics()
+        pp_mem_metrics = self.get_pp_memory_metrics()
+        if extra_metrics is None:
+            extra_metrics = {**moe_metrics, **pp_mem_metrics}
+        else:
+            extra_metrics = {**extra_metrics, **moe_metrics, **pp_mem_metrics}
+
+        super().log(
+            step=step,
+            global_avg_loss=global_avg_loss,
+            global_max_loss=global_max_loss,
+            grad_norm=grad_norm,
+            extra_metrics=extra_metrics,
+        )
+
+
+def build_custom_metrics_processor(
+    job_config: JobConfig,
+    parallel_dims: ParallelDims,
+    model_args: "BaseModelArgs | None" = None,
+    tag: str | None = None,
+) -> MetricsProcessor:
+    """Create a metrics processor.
+
+    Args:
+        job_config (JobConfig): Job configuration.
+        parallel_dims (ParallelDims): Parallel dimensions.
+        model_args (BaseModelArgs | None): Model-specific arguments. Defaults to None.
+        tag (str | None): Tag to use for TensorBoard or WandB. Defaults to None.
+
+    Returns:
+        MetricsProcessor: A metrics processor.
+    """
+    return CustomMetricsProcessor(job_config, parallel_dims, tag)

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import math
 from functools import cache, cached_property
 from typing import TYPE_CHECKING, Any
@@ -62,7 +68,7 @@ class CustomMetricsProcessor(MetricsProcessor):
             return tensor.detach().clone()
         return None
 
-    @cache
+    @cache  # noqa: B019
     def send_moe_layer_idxs_to_metrics_rank(self, rank: int) -> list[int] | None:
         """
         Send MoE layer idxs on `rank` to the metrics rank. Returns the list of idxs on the metric
@@ -115,8 +121,6 @@ class CustomMetricsProcessor(MetricsProcessor):
             for block_idx, transformer_block in model_part.layers.items():
                 if not transformer_block.moe_enabled:
                     continue
-                if transformer_block.moe.load_balance_coeff is None:
-                    return
                 tokens_per_expert_cumulative = (
                     transformer_block.moe.tokens_per_expert_cumulative
                 )

--- a/torchtitan/models/llama3_moe/model/args.py
+++ b/torchtitan/models/llama3_moe/model/args.py
@@ -13,7 +13,7 @@ from torch import nn
 
 from torchtitan.models.llama3_moe.custom_args import JobConfig
 from torchtitan.models.moe import MoEArgs
-from torchtitan.models.utils import get_dense_model_nparams_and_flops
+from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.protocols.model import BaseModelArgs
 from torchtitan.tools.logging import logger
 
@@ -82,4 +82,4 @@ class TransformerModelArgs(BaseModelArgs):
     def get_nparams_and_flops(
         self, model: nn.Module, seq_len: int
     ) -> tuple[int, float]:
-        return get_dense_model_nparams_and_flops(self, model, seq_len)
+        return get_moe_model_nparams_and_flops(self, model, seq_len)

--- a/torchtitan/models/llama3_moe/train_configs/debug_llama3_moe.toml
+++ b/torchtitan/models/llama3_moe/train_configs/debug_llama3_moe.toml
@@ -62,7 +62,7 @@ enable=false
 components = ["model", "loss"]
 
 [activation_checkpoint]
-mode = "none"  # ["none", "selective", "full"]
+mode = "selective"  # ["none", "selective", "full"]
 selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac based on ops policy
 
 [quantize.linear.float8]

--- a/torchtitan/models/llama3_moe/train_configs/llama3_moe.toml
+++ b/torchtitan/models/llama3_moe/train_configs/llama3_moe.toml
@@ -62,7 +62,7 @@ enable=false
 components = ["model", "loss"]
 
 [activation_checkpoint]
-mode = "none"  # ["none", "selective", "full"]
+mode = "selective"  # ["none", "selective", "full"]
 selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac based on ops policy
 
 [quantize.linear.float8]

--- a/torchtitan/models/moe.py
+++ b/torchtitan/models/moe.py
@@ -393,6 +393,13 @@ class MoE(nn.Module):
             torch.zeros(num_experts, dtype=torch.float32),
             persistent=False,
         )
+        # tokens_per_expert is reset every optimizer step, so use tokens_per_expert_cumulative for
+        # metrics reporting and only reset after each report.
+        self.register_buffer(
+            "tokens_per_expert_cumulative",
+            torch.zeros(num_experts, dtype=torch.float32),
+            persistent=False,
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
@@ -485,6 +492,8 @@ class MoE(nn.Module):
             self.tokens_per_expert = torch.zeros(
                 self.experts.num_experts, dtype=torch.float32
             )
+            self.tokens_per_expert_cumulative.zero_()
+
             if self.load_balance_coeff is not None:
                 self.expert_bias = torch.zeros(
                     self.experts.num_experts, dtype=torch.float32


### PR DESCRIPTION
Pulls in some custom metrics infra for tracking things like router entropy. Also corrects the flops utility and turns selective activation ckpting on for `llama3_moe` models.