### PR TITLE
feat: devdict

### DIFF
--- a/tests/llama3_moe/test_model.py
+++ b/tests/llama3_moe/test_model.py
@@ -6,7 +6,11 @@
 
 import torch
 
-from torchtitan.models.llama3_moe import Transformer, TransformerModelArgs
+from torchtitan.models.llama3_moe import (
+    llama3_moe_configs,
+    Transformer,
+    TransformerModelArgs,
+)
 
 
 class TestModel:
@@ -56,3 +60,9 @@ class TestModel:
             self.vocab_size, size=(self.bsz, self.seqlen), device=self.device
         )
         model(inputs)
+
+    def test_dev_cfg(self):
+        dev_cfg = llama3_moe_configs["3B_dev|n_layers=8|n_moe=4|num_experts=3"]
+        assert dev_cfg.n_layers == 8
+        assert dev_cfg.moe_args.num_experts == 3
+        assert dev_cfg.is_moe_list == 4 * [False] + 4 * [True]

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -98,6 +98,7 @@ class devdict(dict):  # noqa: N801
             elif hasattr(cfg.moe_args, k):
                 setattr(cfg.moe_args, k, dev_kwargs.pop(k))
         # Special args:
+        # - n_moe: use this many MoE layers, starting from the last layer backwards
         if "n_moe" in dev_kwargs:
             n_moe = dev_kwargs.pop("n_moe")
             cfg.is_moe_list = [n >= cfg.n_layers - n_moe for n in range(cfg.n_layers)]

--- a/torchtitan/models/llama3_moe/model/model.py
+++ b/torchtitan/models/llama3_moe/model/model.py
@@ -303,8 +303,10 @@ class VirtualGroupMoE(_CustomMoE):
             )
         if self.moe_args.route_scale != self.n_groups:
             raise ValueError(
-                f"{self.moe_args.route_scale} must be divisible by {self.moe_args.hf_ffn_hidden_dim // self.hidden_dim =}"
+                f"{self.moe_args.route_scale=} must be divisible by {self.moe_args.hf_ffn_hidden_dim // self.hidden_dim =}"
             )
+        if self.moe_args.route_norm:
+            raise ValueError(f"{self.moe_args.route_norm=} must be True")
 
     def init_weights(
         self,


### PR DESCRIPTION
Hacky little `dict` subclass which makes it a bit easier to dynamically create a new model config. Example usage: set `flavor="3B_dev|n_layers=8|n_moe=4|num_experts=3"` to get a model with these characteristics.