### PR TITLE
feat: replicate_shuffle weight loading

### DIFF
--- a/tests/llama3_moe/test_dist.py
+++ b/tests/llama3_moe/test_dist.py
@@ -356,10 +356,10 @@ class TestImpls(DTest):
 
     @pytest.mark.parametrize("n_groups", [2, 4], ids=lambda x: f"n_groups={x}")
     @pytest.mark.parametrize("n_replicas", [4, 8], ids=lambda x: f"n_replicas={x}")
-    @pytest.mark.parametrize("weight_transform", ["replicate", "replicate_shuffle"])
+    @pytest.mark.parametrize("hf_weight_transform", ["replicate", "replicate_shuffle"])
     @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
     def test_virtual_group(
-        self, sharding: str, n_groups: int, n_replicas: int, weight_transform: str
+        self, sharding: str, n_groups: int, n_replicas: int, hf_weight_transform: str
     ) -> None:
         """
         Test that the dense and MoE models have the same output with FFN weight replication when

--- a/tests/llama3_moe/test_dist.py
+++ b/tests/llama3_moe/test_dist.py
@@ -15,15 +15,15 @@ from torchtitan.components.checkpoint import CheckpointManager, ModelWrapper
 from torchtitan.distributed import ParallelDims
 from torchtitan.models.llama3_moe import (
     CustomCheckpointManager,
-    get_hf_weight_transform_cls,
-    llama3_moe_configs,
     Llama3MoE,
     Llama3MoEJobConfig,
     Llama3MoEStateDictAdapter,
-    parallelize_llama_moe,
     TransformingHuggingFaceStorageReader,
+    get_hf_weight_transform_cls,
+    llama3_moe_configs,
+    parallelize_llama_moe,
 )
-from torchtitan.models.moe import MoEArgs
+from torchtitan.models.moe import MoE, MoEArgs
 
 
 class TestHFReader(DTest):
@@ -125,11 +125,9 @@ class TestHFReader(DTest):
         model_copy = parallelize_llama_moe(model_copy, parallel_dims, job_config)
 
         model.to_empty(device=self.device)
-        with torch.no_grad():
-            model.init_weights(buffer_device=None)
-
         model_copy.to_empty(device=self.device)
         with torch.no_grad():
+            model.init_weights(buffer_device=None)
             model_copy.init_weights(buffer_device=None)
 
         ckpt_kwargs = {
@@ -191,12 +189,14 @@ class TestHFReader(DTest):
         model_moe = parallelize_llama_moe(model_moe, parallel_dims, job_config)
 
         model.to_empty(device=self.device)
-        with torch.no_grad():
-            model.init_weights(buffer_device=None)
-
         model_moe.to_empty(device=self.device)
         with torch.no_grad():
+            model.init_weights(buffer_device=None)
             model_moe.init_weights(buffer_device=None)
+
+        # Sanity checks:
+        assert not any(isinstance(m, MoE) for m in model.modules())
+        assert any(isinstance(m, MoE) for m in model_moe.modules())
 
         ckpt_kwargs = {
             "dataloader": None,
@@ -286,6 +286,10 @@ class TestImpls(DTest):
             model = Llama3MoE(model_args)
             model_moe = Llama3MoE(model_args_moe)
 
+        # Sanity checks:
+        assert not any(isinstance(m, MoE) for m in model.modules())
+        assert any(isinstance(m, MoE) for m in model_moe.modules())
+
         parallel_dims = ParallelDims(
             dp_shard=-1,
             dp_replicate=1,
@@ -350,12 +354,16 @@ class TestImpls(DTest):
             out_moe = model_moe(inputs)
             torch.testing.assert_close(out, out_moe, atol=self.atol, rtol=self.rtol)
 
-    @pytest.mark.parametrize("n_groups", [2, 4])
-    @pytest.mark.parametrize("n_replicas", [4, 8])
+    @pytest.mark.parametrize("n_groups", [2, 4], ids=lambda x: f"n_groups={x}")
+    @pytest.mark.parametrize("n_replicas", [4, 8], ids=lambda x: f"n_replicas={x}")
+    @pytest.mark.parametrize("weight_transform", ["replicate", "replicate_shuffle"])
     @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
-    def test_virtual_group(self, sharding: str, n_groups: int, n_replicas: int) -> None:
+    def test_virtual_group(
+        self, sharding: str, n_groups: int, n_replicas: int, weight_transform: str
+    ) -> None:
         """
-        Test that the dense and MoE models have the same output with FFN weight replication.
+        Test that the dense and MoE models have the same output with FFN weight replication when
+        using virtual group init and any applicable weight transformation strategy.
         """
         model_args = llama3_moe_configs["3B_2layer"]
         # Dynamically generate a valid moe cfg for a model with one FFN and one MoE layer.
@@ -392,6 +400,10 @@ class TestImpls(DTest):
         with torch.device("meta"):
             model = Llama3MoE(model_args)
             model_moe = Llama3MoE(model_args_moe)
+
+        # Sanity checks:
+        assert not any(isinstance(m, MoE) for m in model.modules())
+        assert any(isinstance(m, MoE) for m in model_moe.modules())
 
         parallel_dims = ParallelDims(
             dp_shard=-1,

--- a/tests/llama3_moe/test_dist.py
+++ b/tests/llama3_moe/test_dist.py
@@ -15,13 +15,13 @@ from torchtitan.components.checkpoint import CheckpointManager, ModelWrapper
 from torchtitan.distributed import ParallelDims
 from torchtitan.models.llama3_moe import (
     CustomCheckpointManager,
+    get_hf_weight_transform_cls,
+    llama3_moe_configs,
     Llama3MoE,
     Llama3MoEJobConfig,
     Llama3MoEStateDictAdapter,
-    TransformingHuggingFaceStorageReader,
-    get_hf_weight_transform_cls,
-    llama3_moe_configs,
     parallelize_llama_moe,
+    TransformingHuggingFaceStorageReader,
 )
 from torchtitan.models.moe import MoE, MoEArgs
 

--- a/torchtitan/models/llama3_moe/hf_reader.py
+++ b/torchtitan/models/llama3_moe/hf_reader.py
@@ -13,10 +13,10 @@ import torch
 from einops import rearrange
 from torch.distributed.checkpoint import HuggingFaceStorageReader
 from torch.distributed.checkpoint._hf_utils import (
+    _HFStorageInfo,
     CUSTOM_METADATA_KEY,
     SAVED_OFFSETS_KEY,
     SUFFIX,
-    _HFStorageInfo,
 )
 from torch.distributed.checkpoint.metadata import (
     ChunkStorageMetadata,
@@ -192,7 +192,8 @@ class _HFWeightTransform(ABC):
         return self.transform(titan_fqn, t)
 
     @abstractmethod
-    def transform(self, titan_fqn: str, t: torch.Tensor) -> torch.Tensor: ...
+    def transform(self, titan_fqn: str, t: torch.Tensor) -> torch.Tensor:
+        ...
 
 
 class ReplicateMoETransform(_HFWeightTransform):

--- a/torchtitan/models/llama3_moe/model/state_dict_adapter.py
+++ b/torchtitan/models/llama3_moe/model/state_dict_adapter.py
@@ -52,9 +52,9 @@ class Llama3MoEStateDictAdapter(StateDictAdapter):
             self.from_hf_map[
                 f"model.layers.{layer_idx}.self_attn.rotary_emb.inv_freq"
             ] = None
-            self.from_hf_map[f"model.layers.{layer_idx}.input_layernorm.weight"] = (
-                f"layers.{layer_idx}.attention_norm.weight"
-            )
+            self.from_hf_map[
+                f"model.layers.{layer_idx}.input_layernorm.weight"
+            ] = f"layers.{layer_idx}.attention_norm.weight"
             self.from_hf_map[
                 f"model.layers.{layer_idx}.post_attention_layernorm.weight"
             ] = f"layers.{layer_idx}.ffn_norm.weight"
@@ -64,14 +64,14 @@ class Llama3MoEStateDictAdapter(StateDictAdapter):
                 ] = f"layers.{layer_idx}.attention.{titan_name}.weight"
             if is_moe:
                 for hf_name, titan_name in moe_name_weight_map.items():
-                    self.from_hf_map[f"model.layers.{layer_idx}.{hf_name}.weight"] = (
-                        f"layers.{layer_idx}.{titan_name}"
-                    )
+                    self.from_hf_map[
+                        f"model.layers.{layer_idx}.{hf_name}.weight"
+                    ] = f"layers.{layer_idx}.{titan_name}"
             else:
                 for hf_name, titan_name in ffn_name_weight_map.items():
-                    self.from_hf_map[f"model.layers.{layer_idx}.{hf_name}.weight"] = (
-                        f"layers.{layer_idx}.{titan_name}.weight"
-                    )
+                    self.from_hf_map[
+                        f"model.layers.{layer_idx}.{hf_name}.weight"
+                    ] = f"layers.{layer_idx}.{titan_name}.weight"
 
     # HuggingFace permutation function (exact copy from their conversion script)
     def _permute(self, w, n_heads_arg, dim1=None, dim2=None):

--- a/torchtitan/models/llama3_moe/model/state_dict_adapter.py
+++ b/torchtitan/models/llama3_moe/model/state_dict_adapter.py
@@ -144,7 +144,7 @@ class Llama3MoEStateDictAdapter(StateDictAdapter):
             warn_once(
                 logger,
                 f"{missing_keys=} are not specified in {self.__class__.__name__}.from_hf_map, "
-                " will not get state loaded into them.",
+                "will not get state loaded into them.",
             )
 
         return hf_state_dict

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -22,15 +22,14 @@ from torchtitan.components.metrics import (
     build_metrics_processor,
     ensure_pp_loss_visible,
 )
-from torchtitan.config import TORCH_DTYPE_MAP, ConfigManager
+from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
 from torchtitan.config.job_config import JobConfig
-from torchtitan.distributed import ParallelDims
-from torchtitan.distributed import utils as dist_utils
+from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.models.attention import init_attention_mask
 from torchtitan.models.llama3_moe import (
     CustomCheckpointManager,
-    TransformingHuggingFaceStorageReader,
     get_hf_weight_transform_cls,
+    TransformingHuggingFaceStorageReader,
 )
 from torchtitan.models.llama3_moe.custom_args import Llama3MoEJobConfig
 from torchtitan.models.llama3_moe.top_k_scheduler import get_top_k_scheduler
@@ -653,8 +652,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 )
 
                 # Run validation if validator is available
-                if self.job_config.validation.enable and self.validator.should_validate(
-                    self.step
+                if (
+                    self.job_config.validation.enable
+                    and self.validator.should_validate(self.step)
                 ):
                     with self.loss_fn.no_rescale():
                         self.validator.validate(self.model_parts, self.step)
@@ -714,12 +714,12 @@ if __name__ == "__main__":
         trainer = Trainer(config)
 
         if config.checkpoint.create_seed_checkpoint:
-            assert int(os.environ["WORLD_SIZE"]) == 1, (
-                "Must create seed checkpoint using a single device, to disable sharding."
-            )
-            assert config.checkpoint.enable, (
-                "Must enable checkpointing when creating a seed checkpoint."
-            )
+            assert (
+                int(os.environ["WORLD_SIZE"]) == 1
+            ), "Must create seed checkpoint using a single device, to disable sharding."
+            assert (
+                config.checkpoint.enable
+            ), "Must enable checkpointing when creating a seed checkpoint."
             trainer.checkpointer.save(curr_step=0, last_step=True)
             logger.info("Created seed checkpoint")
         else:


### PR DESCRIPTION
Rather than loading FFN weights into the MoE by simply replicating and stacking, we can alternatively shuffle the hidden dimension indices of each FFN weight while retaining exact FFN-MoE equivalence. The hope is that this helps differentiate the various experts in a profitable way.  This PR implements this idea and adds e2e tests, along with some minor cleanup.