### PR TITLE
fix: use proper llama rope

### DIFF
--- a/tests/llama3_moe/test_model.py
+++ b/tests/llama3_moe/test_model.py
@@ -15,7 +15,11 @@ from torchtitan.models.llama3_moe import (
     Llama3MoEModelArgs,
     Llama3MoEStateDictAdapter,
 )
-from transformers import AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+TEST_TEXT = "Why did the chicken cross the road? To get to the other side."
+LLAMA_3B_HF_PATH = "/gpfs/goon/models/Llama-3.2-3B/"
+LLAMA_3B_HF_NO_TIED_PATH = "/gpfs/goon/models/Llama-3.2-3B-no-tied-weights/"
 
 
 class TestModel:
@@ -29,7 +33,7 @@ class TestModel:
     bsz = 2
     seqlen = 64
     device = "cuda"
-    hf_assets_path = "/gpfs/goon/models/Llama-3.2-3B-no-tied-weights/"
+    hf_assets_path = LLAMA_3B_HF_NO_TIED_PATH
 
     def test_model_no_moe(self):
         args = Llama3MoEModelArgs(
@@ -94,23 +98,19 @@ class TestModel:
         checkpointer = CheckpointManager(model_parts=[model], **ckpt_kwargs)
         checkpointer.load()
 
-        model_hf = AutoModelForCausalLM.from_pretrained(
-            "/gpfs/goon/models/Llama-3.2-3B/"
-        ).to(device=self.device)
+        model_hf = AutoModelForCausalLM.from_pretrained(LLAMA_3B_HF_PATH).to(
+            device=self.device
+        )
+        tokenizer = AutoTokenizer.from_pretrained(LLAMA_3B_HF_PATH)
+        inputs = tokenizer(TEST_TEXT, return_tensors="pt")
+        for k, v in inputs.items():
+            inputs[k] = v.cuda()
 
         torch.manual_seed(42)
         with torch.no_grad():
-            inputs = torch.randint(
-                model_args.vocab_size, size=(self.bsz, self.seqlen), device=self.device
-            )
-            out = model(inputs)
-            out_hf = model_hf(inputs)
-            # NOTE: @goon -  current mean error ~ 1%. Might be failing due to the RoPE impl
-            # mismatches?
-            torch.testing.assert_close(out_hf.logits, out, atol=1e-1, rtol=1e-1)
-
-    def test_dev_cfg(self):
-        dev_cfg = llama3_moe_configs["3B_dev|n_layers=8|n_moe=4|num_experts=3"]
-        assert dev_cfg.n_layers == 8
-        assert dev_cfg.moe_args.num_experts == 3
-        assert dev_cfg.is_moe_list == 4 * [False] + 4 * [True]
+            out = model(inputs["input_ids"])
+            out_hf = model_hf(**inputs).logits
+            torch.testing.assert_close(out_hf, out, atol=1e-2, rtol=1e-5)
+            p, q = out_hf.softmax(dim=-1), out.softmax(dim=-1)
+            kl = (p * (p / q).log()).sum(dim=-1).mean()
+            kl

--- a/tests/llama3_moe/test_model.py
+++ b/tests/llama3_moe/test_model.py
@@ -113,4 +113,4 @@ class TestModel:
             torch.testing.assert_close(out_hf, out, atol=1e-2, rtol=1e-5)
             p, q = out_hf.softmax(dim=-1), out.softmax(dim=-1)
             kl = (p * (p / q).log()).sum(dim=-1).mean()
-            kl
+            assert kl < 1e-5, f"{kl=}"

--- a/torchtitan/models/llama3_moe/model/args.py
+++ b/torchtitan/models/llama3_moe/model/args.py
@@ -29,7 +29,7 @@ class Llama3MoEModelArgs(BaseModelArgs):
     multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
     ffn_dim_multiplier: float | None = None
     norm_eps: float = 1e-5
-    rope_theta: float = 10000
+    rope_theta: float = 500000.0
     custom_moe_impl: str | None = None
 
     # MoE
@@ -50,9 +50,7 @@ class Llama3MoEModelArgs(BaseModelArgs):
 
     # yarn: https://arxiv.org/pdf/2309.00071
     original_seq_len: int = 8192
-    rope_factor: float = 20  # s in 2309.00071 (I believe); see eq (25)
-    beta_fast: int = 32  # \alpha in 2309.00071; see around eq (23)
-    beta_slow: int = 1  # \beta in 2309.00071; see around eq (23)
+    rope_impl: str = "llama"  # llama or dsv3
 
     def update_from_config(self, job_config: Llama3MoEJobConfig, **kwargs) -> None:
         seq_len = job_config.training.seq_len

--- a/torchtitan/models/moe.py
+++ b/torchtitan/models/moe.py
@@ -379,7 +379,7 @@ class MoE(nn.Module):
         #       to work with gradient accumulation.
         self.load_balance_coeff = moe_args.load_balance_coeff
         if self.load_balance_coeff is not None:
-            assert self.load_balance_coeff > 0.0
+            assert self.load_balance_coeff >= 0.0
             self.register_buffer(
                 "expert_bias",
                 torch.zeros(num_experts, dtype=torch.float32),


### PR DESCRIPTION
We were using YaRN RoPE, but should really be using Llama's RoPE. [The latter was added to torchtitan recently](https://github.com/pytorch/torchtitan/pull/1839/files), and this PR ports it to our branch. Bring the HF and torchtitan models into better agreement, though they're still not as close as reported in the above PR.