### PR TITLE
fix: do not MoE final layer

### DIFF
--- a/tests/llama3_moe/test_dist.py
+++ b/tests/llama3_moe/test_dist.py
@@ -381,7 +381,7 @@ class TestImpls(DTest):
         )
         model_args_moe.moe_args = moe_args
         model_args_moe.moe_inter_dim = llama_3b_hidden_dim // n_groups
-        model_args_moe.is_moe_list = [False, True]
+        model_args_moe.is_moe_list = [True, False]
         model_args_moe.custom_moe_impl = "virtual_group"
 
         job_config = Llama3MoEJobConfig()

--- a/torchtitan/models/llama3_moe/model/args.py
+++ b/torchtitan/models/llama3_moe/model/args.py
@@ -74,9 +74,17 @@ class Llama3MoEModelArgs(BaseModelArgs):
                 setattr(self.moe_args, k, v)
         # Special arg handling:
         if (n_moe_layers := job_config.model_overrides.n_moe_layers) is not None:
-            self.is_moe_list = (self.n_layers - n_moe_layers) * [
-                False
-            ] + n_moe_layers * [True]
+            if n_moe_layers >= self.n_layers - 1:
+                raise ValueError(
+                    f"Must have {n_moe_layers=} larger than {self.n_layers - 1 =}"
+                    "n_moe_layers inserts MoE layers starting from the second to last layer"
+                    " following the advice of https://arxiv.org/pdf/2403.17887 sec 4.4"
+                )
+            self.is_moe_list = (
+                (self.n_layers - n_moe_layers - 1) * [False]
+                + n_moe_layers * [True]
+                + [False]
+            )
 
         if self.is_moe_list is not None and len(self.is_moe_list) != self.n_layers:
             raise ValueError(


### PR DESCRIPTION
Per https://arxiv.org/pdf/2403.17887, e.g. Sec. 4.4, the very last layer is important, so we should probably only start swapping out FFN --> MoE starting at the penultimate layer.