### PR TITLE
moe feats: router metrics and custom router init std

### DIFF
--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -149,6 +149,7 @@ def build_lr_schedulers(
         1. `linear`: decays linearly from 1 to 0 over the decay period.
         2. `sqrt`: decays as 1 minus the square root of the decay progress.
         3. `cosine`: follows a cosine curve, decaying according to the values of the half-period of the cosine function.
+        4. `constant`: just constant, after the warmup phase.
 
         If `min_lr_factor` is specified, the decay range is scaled from 1 to `min_lr_factor`
         to ensure the learning rate does not drop below this minimum value.
@@ -176,6 +177,10 @@ def build_lr_schedulers(
                 curr_adjustment = 1 - math.sqrt(progress)
             elif lr_decay_type == "cosine":
                 curr_adjustment = 0.5 * (1.0 + math.cos(math.pi * progress))
+            elif lr_decay_type == "constant":
+                curr_adjustment = 1
+            else:
+                raise ValueError(f"Unexpected {lr_decay_type=}")
             curr_adjustment = min_lr_factor + (1 - min_lr_factor) * curr_adjustment
         return curr_adjustment
 

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -152,7 +152,7 @@ class LRScheduler:
     This is known as the Warmup-Stable-Decay (WSD) schedule, as described in https://arxiv.org/abs/2404.06395.
     """
 
-    decay_type: Literal["linear", "sqrt", "cosine"] = "linear"
+    decay_type: Literal["linear", "sqrt", "cosine", "constant"] = "linear"
     """
     Learning rate decay type to use during training:
     - 'linear': linearly decays learning rate from initial to final value

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -158,6 +158,7 @@ class LRScheduler:
     - 'linear': linearly decays learning rate from initial to final value
     - 'sqrt': decays learning rate following a 1 minus square root curve
     - 'cosine': smoothly decays learning rate following a cosine curve
+    - 'constant': constant
     """
 
     min_lr_factor: float = 0.0

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -62,7 +62,7 @@ class MoEOverrides:
     n_expert_groups: int | None = None
     top_k_group: int | None = None
     # Custom args
-    moe_router_init_std: int | None = None
+    moe_router_init_std: float | None = None
 
 
 @dataclass

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -61,6 +61,8 @@ class MoEOverrides:
     hf_ffn_hidden_dim: int | None | None = None
     n_expert_groups: int | None = None
     top_k_group: int | None = None
+    # Custom args
+    moe_router_init_std: int | None = None
 
 
 @dataclass

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -62,7 +62,7 @@ class MoEOverrides:
     n_expert_groups: int | None = None
     top_k_group: int | None = None
     # Custom args
-    moe_router_init_std: float | None = None
+    router_init_std: float | None = None
 
 
 @dataclass

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import TYPE_CHECKING, Any
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -30,9 +30,9 @@ class CustomMetricsProcessor(MetricsProcessor):
             for block_idx, transformer_block in model_part.layers.items():
                 if not transformer_block.moe_enabled:
                     continue
-                moe_metrics[f"moe_entropy/layer_{block_idx}"] = (
-                    self.get_normalized_entropy(transformer_block)
-                )
+                moe_metrics[
+                    f"moe_entropy/layer_{block_idx}"
+                ] = self.get_normalized_entropy(transformer_block)
                 if (
                     n_expert_groups := model_part.model_args.moe_args.n_expert_groups
                 ) > 1:
@@ -49,15 +49,15 @@ class CustomMetricsProcessor(MetricsProcessor):
                 moe_metrics[f"moe_router/layer_{block_idx} abs mean"] = (
                     router_weight.abs().mean().item()
                 )
-                moe_metrics[f"moe_router/layer_{block_idx} std"] = (
-                    router_weight.std().item()
-                )
-                moe_metrics[f"moe_router/layer_{block_idx} min"] = (
-                    router_weight.min().item()
-                )
-                moe_metrics[f"moe_router/layer_{block_idx} max"] = (
-                    router_weight.max().item()
-                )
+                moe_metrics[
+                    f"moe_router/layer_{block_idx} std"
+                ] = router_weight.std().item()
+                moe_metrics[
+                    f"moe_router/layer_{block_idx} min"
+                ] = router_weight.min().item()
+                moe_metrics[
+                    f"moe_router/layer_{block_idx} max"
+                ] = router_weight.max().item()
 
         return moe_metrics
 

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -83,7 +83,7 @@ class CustomMetricsProcessor(MetricsProcessor):
     def get_expert_group_normalized_group_entropy(
         self, transformer_block: nn.Module, n_expert_groups: int
     ) -> float:
-        tokens_per_expert_group_cumulative_prob = (
+        tokens_per_expert_group_cumulative = (
             transformer_block.moe.tokens_per_expert_cumulative.reshape(
                 n_expert_groups, -1
             ).sum(dim=-1)

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -33,11 +33,13 @@ class CustomMetricsProcessor(MetricsProcessor):
                 moe_metrics[f"moe/layer_{block_idx} moe normalized entropy"] = (
                     self.get_normalized_entropy(transformer_block)
                 )
-                if model_part.model_args.moe_args.n_expert_groups > 1:
+                if (
+                    n_expert_groups := model_part.model_args.moe_args.n_expert_groups
+                ) > 1:
                     moe_metrics[
                         f"moe/layer_{block_idx} moe expert_group normalized entropy"
                     ] = self.get_expert_group_normalized_group_entropy(
-                        transformer_block
+                        transformer_block, n_expert_groups
                     )
                 # Reset
                 transformer_block.moe.tokens_per_expert_cumulative.zero_()
@@ -79,11 +81,11 @@ class CustomMetricsProcessor(MetricsProcessor):
         return normalized_entropy
 
     def get_expert_group_normalized_group_entropy(
-        self, transformer_block: nn.Module
+        self, transformer_block: nn.Module, n_expert_groups: int
     ) -> float:
         tokens_per_expert_group_cumulative_prob = (
             transformer_block.moe.tokens_per_expert_cumulative.reshape(
-                n_expert_group_groups, -1
+                n_expert_groups, -1
             ).sum(dim=-1)
             + self.eps
         )

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -5,15 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from functools import cache, cached_property
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-import torch
-import torch.distributed as dist
-import torch.distributed._functional_collectives as funcol
-import torch.distributed.distributed_c10d as c10d
+from torch.distributed.tensor import DTensor
 
-from torchtitan.components.metrics import _get_metrics_rank, MetricsProcessor
+from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.distributed import ParallelDims
 from torchtitan.models.llama3_moe.custom_args import Llama3MoEJobConfig
 
@@ -22,223 +18,87 @@ if TYPE_CHECKING:
 
 
 class CustomMetricsProcessor(MetricsProcessor):
-    eps = 1e-5
-    device = "cuda"
+    eps = 1e-10
 
-    @cached_property
-    def rank(self) -> int:
-        return dist.get_rank()
-
-    @cached_property
-    def metrics_rank(self) -> int:
-        return _get_metrics_rank(self.parallel_dims, self.job_config)
-
-    @cached_property
-    def moe_layer_idxs(self) -> list[int]:
-        """
-        The MoE layer idxs on the present rank.
-        """
-        moe_layer_idxs = []
-        for model_part in self.model_parts:
-            for block_idx, transformer_block in model_part.layers.items():
-                if transformer_block.moe_enabled:
-                    moe_layer_idxs.append(int(block_idx))
-        return moe_layer_idxs
-
-    def send_tensor_to_metrics_rank(
-        self, rank: int, tensor: torch.Tensor
-    ) -> torch.Tensor | None:
-        """
-        Send the given tensor from rank to the metrics_rank process. metrics_rank passes in its
-        receive buffer. The recv buffer will be modified in-place, and a copy returned.
-        """
-        if self.rank not in (rank, self.metrics_rank):
-            return None
-
-        ops = []
-        if rank == self.rank:
-            ops.append(dist.P2POp(dist.isend, tensor, self.metrics_rank))
-        else:
-            ops.append(dist.P2POp(dist.irecv, tensor, rank))
-        for op in dist.batch_isend_irecv(ops):
-            op.wait()
-
-        if self.rank == self.metrics_rank:
-            return tensor.detach().clone()
-        return None
-
-    @cache  # noqa: B019
-    def send_moe_layer_idxs_to_metrics_rank(self, rank: int) -> list[int] | None:
-        """
-        Send MoE layer idxs on `rank` to the metrics rank. Returns the list of idxs on the metric
-        rank, and None on all others.
-
-        Two steps:
-        1. Send the number of idxs to expect
-        2. Send the idxs
-        """
-        if self.rank not in (rank, self.metrics_rank):
-            return None
-
-        # Send num idxs to expect
-        num_results = (
-            torch.tensor(
-                [len(self.moe_layer_idxs)], device=self.device, dtype=torch.int32
-            )
-            if rank == self.rank
-            else torch.empty(1, device=self.device, dtype=torch.int32)
-        )
-        num_results = self.send_tensor_to_metrics_rank(rank, num_results)
-
-        # Send idxs
-        layer_idxs = (
-            torch.tensor(self.moe_layer_idxs, device=self.device, dtype=torch.int32)
-            if rank == self.rank
-            else torch.empty(
-                int(num_results.item()), device=self.device, dtype=torch.int32
-            )
-        )
-        layer_idxs = self.send_tensor_to_metrics_rank(rank, layer_idxs)
-        if self.rank == self.metrics_rank:
-            return layer_idxs.tolist()
-        return None
-
-    def get_moe_balancing_metrics(self) -> dict[str, Any]:
-        pp_ranks = (
-            self.parallel_dims.world_mesh["pp"].mesh.tolist()
-            if self.parallel_dims.pp_enabled
-            else []
-        )
-        # Early return for irrelevant ranks. MoE optimizer code has already reduced tok counts
-        # across the dp_cp dim.
-        if self.rank != self.metrics_rank and self.metrics_rank not in pp_ranks:
-            return {}
-
+    @torch.no_grad
+    def get_moe_metrics(self) -> dict[str, Any]:
         moe_metrics = {}
         # Get locally-available MoE stats on relevant ranks
         for model_part in self.model_parts:
             for block_idx, transformer_block in model_part.layers.items():
                 if not transformer_block.moe_enabled:
                     continue
-                tokens_per_expert_cumulative = (
-                    transformer_block.moe.tokens_per_expert_cumulative
+                moe_metrics[f"moe/layer_{block_idx} moe normalized entropy"] = (
+                    self.get_normalized_entropy(transformer_block)
                 )
-
-                tokens_per_expert_cumulative_prob = (
-                    tokens_per_expert_cumulative + self.eps
-                ) / (tokens_per_expert_cumulative + self.eps).sum()
-                entropy = (
-                    -tokens_per_expert_cumulative_prob.log()
-                    * tokens_per_expert_cumulative_prob
-                ).sum()
-                max_entropy = math.log(tokens_per_expert_cumulative_prob.numel())
-                moe_metrics[int(block_idx)] = entropy / max_entropy
-                transformer_block.moe.tokens_per_expert_cumulative.zero_()
-
-        # If using PP, need to also gather stats from other PP ranks.
-        for send_rank in pp_ranks:
-            if send_rank == self.metrics_rank:
-                continue
-            if self.rank in (send_rank, self.metrics_rank):
-                # Send/get cached moe idxs from send_rank
-                send_rank_idxs = self.send_moe_layer_idxs_to_metrics_rank(send_rank)
-                # Send results
-                results = (
-                    torch.stack(list(moe_metrics.values()), dim=-1)
-                    if send_rank == self.rank
-                    else torch.empty(
-                        len(send_rank_idxs),
-                        device=self.device,
+                if model_part.model_args.moe_args.n_expert_groups > 1:
+                    moe_metrics[
+                        f"moe/layer_{block_idx} moe expert_group normalized entropy"
+                    ] = self.get_expert_group_normalized_group_entropy(
+                        transformer_block
                     )
+                # Reset
+                transformer_block.moe.tokens_per_expert_cumulative.zero_()
+                router_weight = transformer_block.moe.router.gate.weight
+                if isinstance(router_weight, DTensor):
+                    router_weight = router_weight.full_tensor()
+                moe_metrics[f"moe/layer_{block_idx} router abs mean"] = (
+                    router_weight.abs().mean().item()
                 )
-                results = self.send_tensor_to_metrics_rank(send_rank, results)
+                moe_metrics[f"moe/layer_{block_idx} router std"] = (
+                    router_weight.std().item()
+                )
+                moe_metrics[f"moe/layer_{block_idx} router min"] = (
+                    router_weight.min().item()
+                )
+                moe_metrics[f"moe/layer_{block_idx} router max"] = (
+                    router_weight.max().item()
+                )
 
-                if self.rank == self.metrics_rank:
-                    for idx, res in zip(send_rank_idxs, results, strict=True):
-                        moe_metrics[idx] = res
+        return moe_metrics
 
-        if self.rank != self.metrics_rank:
-            return {}
-        return {
-            f"moe/layer_{block_idx} moe normalized entropy": e.item()
-            for block_idx, e in moe_metrics.items()
-        }
-
-    def get_pp_memory_metrics(self) -> dict[str, Any]:
-        """
-        Get the CUDA memory metrics on each PP rank, max-reduced over the dp_cp group, if it exists.
-        """
-        if not self.parallel_dims.pp_enabled:
-            return {}
-
-        device_mem_stats = self.device_memory_monitor.get_peak_stats()
-        # Put mem stats in a tensor. Order
-        # 0: "memory/max_active(GiB)": device_mem_stats.max_active_gib,
-        # 1: "memory/max_active(%)": device_mem_stats.max_active_pct,
-        # 2: "memory/max_reserved(GiB)": device_mem_stats.max_reserved_gib,
-        # 3: "memory/max_reserved(%)": device_mem_stats.max_reserved_pct,
-        # 4: "memory/num_alloc_retries": device_mem_stats.num_alloc_retries,
-        # 5: "memory/num_ooms": device_mem_stats.num_ooms,
-        mem_stat_prefixes = [
-            "memory/max_active(GiB)",
-            "memory/max_active(%)",
-            "memory/max_reserved(GiB)",
-            "memory/max_reserved(%)",
-            "memory/num_alloc_retries",
-            "memory/num_ooms",
-        ]
-        mem_stats_t = torch.tensor(
-            [
-                device_mem_stats.max_active_gib,
-                device_mem_stats.max_active_pct,
-                device_mem_stats.max_reserved_gib,
-                device_mem_stats.max_reserved_pct,
-                device_mem_stats.num_alloc_retries,
-                device_mem_stats.num_ooms,
-            ],
-            dtype=torch.float32,
-            device=self.device,
+    def get_normalized_entropy(self, transformer_block: nn.Module) -> float:
+        tokens_per_expert_cumulative = (
+            transformer_block.moe.tokens_per_expert_cumulative + self.eps
         )
-        if self.rank == self.metrics_rank:
-            recv_mem_stats_buffer_t = mem_stats_t.clone()
-
-        if self.parallel_dims.dp_cp_enabled:
-            mem_stats_t = funcol.all_reduce(
-                mem_stats_t,
-                reduceOp=c10d.ReduceOp.MAX.name,
-                group=self.parallel_dims.world_mesh["dp_cp"],
+        tokens_per_expert_cumulative_prob = (
+            tokens_per_expert_cumulative
+        ) / tokens_per_expert_cumulative.sum()
+        entropy = (
+            (
+                -tokens_per_expert_cumulative_prob.log()
+                * tokens_per_expert_cumulative_prob
             )
+            .sum()
+            .item()
+        )
+        max_entropy = math.log(tokens_per_expert_cumulative_prob.numel())
+        normalized_entropy = entropy / max_entropy
+        return normalized_entropy
 
-        pp_ranks = self.parallel_dims.world_mesh["pp"].mesh.tolist()
-        # Only other members of the metrics rank's PP group need to send info. Early return for
-        # irrelevant ranks.
-        if self.metrics_rank not in pp_ranks:
-            return {}
-
-        # Use the enumerated idx of the rank as the PP rank (e.g. we use the mesh-local-rank)
-        pp_mem_metrics_t = {}
-        for pp_mesh_rank, send_rank in enumerate(pp_ranks):
-            if send_rank == self.metrics_rank:
-                pp_mem_metrics_t[pp_mesh_rank] = mem_stats_t
-                continue
-            if self.rank in (send_rank, self.metrics_rank):
-                recv_mem_stats_t = self.send_tensor_to_metrics_rank(
-                    send_rank,
-                    mem_stats_t if self.rank == send_rank else recv_mem_stats_buffer_t,
-                )
-                pp_mem_metrics_t[pp_mesh_rank] = recv_mem_stats_t
-        if self.rank != self.metrics_rank:
-            return {}
-        # Turn the tensorial mem metrics into nicely formatted ones
-        pp_mem_metrics = {}
-        for pp_mesh_rank, mem_t in pp_mem_metrics_t.items():
-            for metric_name, metric_val in zip(
-                mem_stat_prefixes, mem_t.tolist(), strict=True
-            ):
-                pp_mem_metrics[
-                    metric_name + f" pp mesh rank {pp_mesh_rank}"
-                ] = metric_val
-        return pp_mem_metrics
+    def get_expert_group_normalized_group_entropy(
+        self, transformer_block: nn.Module
+    ) -> float:
+        tokens_per_expert_group_cumulative_prob = (
+            transformer_block.moe.tokens_per_expert_group_cumulative.reshape(
+                n_expert_group_groups, -1
+            ).sum(dim=-1)
+            + self.eps
+        )
+        tokens_per_expert_group_cumulative_prob = (
+            tokens_per_expert_group_cumulative
+        ) / tokens_per_expert_group_cumulative.sum()
+        entropy = (
+            (
+                -tokens_per_expert_group_cumulative_prob.log()
+                * tokens_per_expert_group_cumulative_prob
+            )
+            .sum()
+            .item()
+        )
+        max_entropy = math.log(tokens_per_expert_group_cumulative_prob.numel())
+        normalized_entropy = entropy / max_entropy
+        return normalized_entropy
 
     def log(
         self,
@@ -248,12 +108,11 @@ class CustomMetricsProcessor(MetricsProcessor):
         grad_norm: float,
         extra_metrics: dict[str, Any] | None = None,
     ) -> None:
-        moe_metrics = self.get_moe_balancing_metrics()
-        pp_mem_metrics = self.get_pp_memory_metrics()
+        moe_metrics = self.get_moe_metrics()
         if extra_metrics is None:
-            extra_metrics = {**moe_metrics, **pp_mem_metrics}
+            extra_metrics = {**moe_metrics}
         else:
-            extra_metrics = {**extra_metrics, **moe_metrics, **pp_mem_metrics}
+            extra_metrics = {**extra_metrics, **moe_metrics}
 
         super().log(
             step=step,

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -8,6 +8,7 @@ import math
 from typing import TYPE_CHECKING, Any
 
 import torch
+import torch.nn as nn
 from torch.distributed.tensor import DTensor
 
 from torchtitan.components.metrics import MetricsProcessor

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -30,14 +30,14 @@ class CustomMetricsProcessor(MetricsProcessor):
             for block_idx, transformer_block in model_part.layers.items():
                 if not transformer_block.moe_enabled:
                     continue
-                moe_metrics[f"moe/layer_{block_idx} moe normalized entropy"] = (
+                moe_metrics[f"moe_entropy/layer_{block_idx}"] = (
                     self.get_normalized_entropy(transformer_block)
                 )
                 if (
                     n_expert_groups := model_part.model_args.moe_args.n_expert_groups
                 ) > 1:
                     moe_metrics[
-                        f"moe/layer_{block_idx} moe expert_group normalized entropy"
+                        f"moe_group_entropy/layer_{block_idx}"
                     ] = self.get_expert_group_normalized_group_entropy(
                         transformer_block, n_expert_groups
                     )
@@ -46,16 +46,16 @@ class CustomMetricsProcessor(MetricsProcessor):
                 router_weight = transformer_block.moe.router.gate.weight
                 if isinstance(router_weight, DTensor):
                     router_weight = router_weight.full_tensor()
-                moe_metrics[f"moe/layer_{block_idx} router abs mean"] = (
+                moe_metrics[f"moe_router/layer_{block_idx} abs mean"] = (
                     router_weight.abs().mean().item()
                 )
-                moe_metrics[f"moe/layer_{block_idx} router std"] = (
+                moe_metrics[f"moe_router/layer_{block_idx} std"] = (
                     router_weight.std().item()
                 )
-                moe_metrics[f"moe/layer_{block_idx} router min"] = (
+                moe_metrics[f"moe_router/layer_{block_idx} min"] = (
                     router_weight.min().item()
                 )
-                moe_metrics[f"moe/layer_{block_idx} router max"] = (
+                moe_metrics[f"moe_router/layer_{block_idx} max"] = (
                     router_weight.max().item()
                 )
 

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -7,6 +7,7 @@
 import math
 from typing import TYPE_CHECKING, Any
 
+import torch
 from torch.distributed.tensor import DTensor
 
 from torchtitan.components.metrics import MetricsProcessor

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -82,7 +82,7 @@ class CustomMetricsProcessor(MetricsProcessor):
         self, transformer_block: nn.Module
     ) -> float:
         tokens_per_expert_group_cumulative_prob = (
-            transformer_block.moe.tokens_per_expert_group_cumulative.reshape(
+            transformer_block.moe.tokens_per_expert_cumulative.reshape(
                 n_expert_group_groups, -1
             ).sum(dim=-1)
             + self.eps

--- a/torchtitan/models/llama3_moe/model/model.py
+++ b/torchtitan/models/llama3_moe/model/model.py
@@ -329,6 +329,9 @@ class VirtualGroupMoE(_CustomMoE):
         buffer_device: torch.device,
     ):
         super().init_weights(init_std=init_std, buffer_device=buffer_device)
+        self.post_init()
+
+    def post_init(self) -> None:
         if self.n_groups > 1:
             with torch.no_grad():
                 # Weight shape: (num_experts, dim) = (n_replicas * n_groups, dim)

--- a/torchtitan/models/llama3_moe/model/model.py
+++ b/torchtitan/models/llama3_moe/model/model.py
@@ -18,6 +18,7 @@ from torchtitan.models.llama3.model.model import Attention, FeedForward
 from torchtitan.models.llama3_moe.model.args import Llama3MoEModelArgs
 from torchtitan.models.moe import MoE, MoEArgs
 from torchtitan.protocols.train_spec import ModelProtocol
+from torchtitan.tools.logging import logger
 
 # NOTE: @goon - we pull in both the dsv3 yarn impl, as well as the llama style rope impl
 
@@ -333,6 +334,7 @@ class VirtualGroupMoE(_CustomMoE):
 
     def post_init(self) -> None:
         if self.n_groups > 1:
+            logger.info("Apply virtual_group init.")
             with torch.no_grad():
                 # Weight shape: (num_experts, dim) = (n_replicas * n_groups, dim)
                 router_weights = self.router.gate.weight

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -269,7 +269,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 m.train()
                 if (
                     hasattr(job_config, "moe_overrides")
-                    and (std := job_config.moe_overrides.moe_router_init_std)
+                    and (std := job_config.moe_overrides.router_init_std)
                     is not None
                 ):
                     logger.info(f"Intializing router weights with {std=}")

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -274,7 +274,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 ):
                     for maybe_router_mod in m.modules():
                         if isinstance(maybe_router_mod, TokenChoiceTopKRouter):
-                            nn.init.normal_(maybe_router_mod.gate.weight, std=std)
+                            nn.init.trunc_normal_(maybe_router_mod.gate.weight, std=std)
 
             # confirm that user will be able to view loss metrics on the console
             ensure_pp_loss_visible(parallel_dims, job_config, color)

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -14,7 +14,6 @@ import torch
 import torch.nn as nn
 from torch.distributed.elastic.multiprocessing.errors import record
 
-from torchtitan.models.moe import MoE
 import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager, ModelWrapper
 from torchtitan.components.dataloader import DataloaderExhaustedError
@@ -35,6 +34,8 @@ from torchtitan.models.llama3_moe import (
 )
 from torchtitan.models.llama3_moe.custom_args import Llama3MoEJobConfig
 from torchtitan.models.llama3_moe.top_k_scheduler import get_top_k_scheduler
+
+from torchtitan.models.moe import MoE
 from torchtitan.protocols.model_converter import build_model_converters
 from torchtitan.tools import utils
 from torchtitan.tools.logging import init_logger, logger
@@ -269,8 +270,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 m.train()
                 if (
                     hasattr(job_config, "moe_overrides")
-                    and (std := job_config.moe_overrides.router_init_std)
-                    is not None
+                    and (std := job_config.moe_overrides.router_init_std) is not None
                 ):
                     logger.info(f"Intializing router weights with {std=}")
                     for maybe_moe in model.modules():
@@ -292,8 +292,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 model.init_weights(buffer_device=buffer_device)
             if (
                 hasattr(job_config, "moe_overrides")
-                and (std := job_config.moe_overrides.router_init_std)
-                is not None
+                and (std := job_config.moe_overrides.router_init_std) is not None
             ):
                 logger.info(f"Intializing router weights with {std=}")
                 for maybe_moe in model.modules():

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -272,6 +272,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                     and (std := job_config.moe_overrides.moe_router_init_std)
                     is not None
                 ):
+                    logger.info(f"Intializing router weights with {std=}")
                     for maybe_router_mod in m.modules():
                         if isinstance(maybe_router_mod, TokenChoiceTopKRouter):
                             nn.init.trunc_normal_(maybe_router_mod.gate.weight, std=std)


### PR DESCRIPTION
Cleans up and extends the logged wandb MoE metrics and makes the std of the router init scale customizable.

Also adds a `"constant"` lr scheduler.