### PR TITLE
fix: Llama 3.2 3B RoPE cfg

### DIFF
--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -26,7 +26,7 @@ from torchtitan.models.llama3_moe.metrics import (
     build_custom_metrics_processor,
     CustomMetricsProcessor,
 )
-from torchtitan.models.llama3_moe.model.args import Llama3MoEModelArgs
+from torchtitan.models.llama3_moe.model.args import Llama3MoEModelArgs, RoPEScalingArgs
 from torchtitan.models.llama3_moe.model.model import Llama3MoE, VirtualGroupMoE
 from torchtitan.models.llama3_moe.model.state_dict_adapter import (
     Llama3MoEStateDictAdapter,
@@ -54,6 +54,13 @@ __all__ = [
     "parallelize_llama_moe",
     "pipeline_llama",
 ]
+
+llama_3p2_3b_rope_cfg = RoPEScalingArgs(
+    scaling_factor=32,
+    low_freq_factor=1.0,
+    high_freq_factor=4.0,
+    original_max_position_embeddings=8192,
+)
 
 
 llama3_moe_configs = {
@@ -150,6 +157,7 @@ llama3_moe_configs = {
             score_before_experts=False,
             top_k=2,
         ),
+        rope_scaling_args=llama_3p2_3b_rope_cfg,
     ),
     # NOTE: @goon - the 3B_2layer and 3B_2layer_halfmoe models are used in
     # torchtitan/tests/llama3_moe/test_dist.py, do not delete!
@@ -172,6 +180,7 @@ llama3_moe_configs = {
             score_before_experts=False,
             top_k=2,
         ),
+        rope_scaling_args=llama_3p2_3b_rope_cfg,
     ),
     "3B_2layer_halfmoe": Llama3MoEModelArgs(
         dim=3072,
@@ -191,6 +200,7 @@ llama3_moe_configs = {
             top_k=2,
         ),
         is_moe_list=[False, True],
+        rope_scaling_args=llama_3p2_3b_rope_cfg,
     ),
     # See VirtualGroupMoE for necessary cfg requirements for virtual_group init.
     "3B_2layer_halfmoe_finegrained": Llama3MoEModelArgs(
@@ -214,6 +224,7 @@ llama3_moe_configs = {
         ),
         is_moe_list=[False, True],
         custom_moe_impl="virtual_group",  # Must specify for virtual_group router init!
+        rope_scaling_args=llama_3p2_3b_rope_cfg,
     ),
     "8B": Llama3MoEModelArgs(
         dim=4096,

--- a/torchtitan/models/llama3_moe/model/args.py
+++ b/torchtitan/models/llama3_moe/model/args.py
@@ -18,6 +18,16 @@ from torchtitan.protocols.model import BaseModelArgs
 from torchtitan.tools.logging import logger
 
 
+# From
+# https://github.com/pytorch/torchtitan/blob/89c631cdcefd05885af511513507099148f2bd1d/torchtitan/models/llama3/model/model.py?plain=1#L30
+@dataclass
+class RoPEScalingArgs:
+    scaling_factor: float = 8.0
+    low_freq_factor: float = 1.0
+    high_freq_factor: float = 4.0
+    original_max_position_embeddings: int = 8192
+
+
 @dataclass
 class Llama3MoEModelArgs(BaseModelArgs):
     dim: int = 4096
@@ -31,6 +41,7 @@ class Llama3MoEModelArgs(BaseModelArgs):
     norm_eps: float = 1e-5
     rope_theta: float = 500000.0
     custom_moe_impl: str | None = None
+    rope_scaling_args: RoPEScalingArgs = field(default_factory=RoPEScalingArgs)
 
     # MoE
     moe_args: MoEArgs = field(default_factory=MoEArgs)


### PR DESCRIPTION
Better late than never: found at least one cfg diff that was causing some issues. The 3B rope config is slightly different from the 8B ones. Differences for the old and new configs for `tests/llama3_moe/test_model.py::TestModel::test_hf_equivalence` for the KL divergence and mean squared error between torchtitan and HF models:

```
old model:
dap> . kl
tensor(7.5900e-06, device='cuda:0')
dap> . mse
tensor(0.0046, device='cuda:0')


new model:
dap> . kl
tensor(7.6970e-09, device='cuda:0')
dap> . mse
tensor(3.7638e-06, device='cuda:0')
```