### PR TITLE
feat: token router hooks

### DIFF
--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -63,6 +63,7 @@ class MoEOverrides:
     top_k_group: int | None = None
     # Custom args
     router_init_std: float | None = None
+    router_hooks: bool = True
 
 
 @dataclass

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -29,7 +29,7 @@ class Hook:
     ) -> None:
         self.module = module
         self.module.register_forward_hook(self)
-        self.fqn = fqn.replace("_checkpoint_wrapped_module.moe", "")
+        self.fqn = fqn.replace("_checkpoint_wrapped_module.", "")
         self.parallel_dims = parallel_dims
 
     def __call__(self, module: nn.Module, args, output) -> None:

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -5,8 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from dataclasses import field
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
@@ -100,7 +99,8 @@ class RouterHook(Hook):
 
 class CustomMetricsProcessor(MetricsProcessor):
     eps = 1e-10
-    hooks: list[Hook] = field(default_factory=list)
+    # Bad mutable default, but field(default_factory=list) is erroring, maybe b/c of subclassing?
+    hooks: list[Hook] = []
 
     @torch.no_grad
     def get_moe_metrics(self) -> dict[str, Any]:
@@ -110,16 +110,16 @@ class CustomMetricsProcessor(MetricsProcessor):
             for block_idx, transformer_block in model_part.layers.items():
                 if not transformer_block.moe_enabled:
                     continue
-                moe_metrics[
-                    f"moe_entropy/layer_{block_idx}"
-                ] = self.get_normalized_entropy(transformer_block)
+                moe_metrics[f"moe_entropy/layer_{block_idx}"] = (
+                    self.get_normalized_entropy(transformer_block)
+                )
                 if (
                     n_expert_groups := model_part.model_args.moe_args.n_expert_groups
                 ) > 1:
-                    moe_metrics[
-                        f"moe_group_entropy/layer_{block_idx}"
-                    ] = self.get_expert_group_normalized_group_entropy(
-                        transformer_block, n_expert_groups
+                    moe_metrics[f"moe_group_entropy/layer_{block_idx}"] = (
+                        self.get_expert_group_normalized_group_entropy(
+                            transformer_block, n_expert_groups
+                        )
                     )
                 # Reset
                 transformer_block.moe.tokens_per_expert_cumulative.zero_()
@@ -129,9 +129,9 @@ class CustomMetricsProcessor(MetricsProcessor):
                 moe_metrics[f"moe_router/layer_{block_idx} abs mean"] = (
                     router_weight.abs().mean().item()
                 )
-                moe_metrics[
-                    f"moe_router/layer_{block_idx} std"
-                ] = router_weight.std().item()
+                moe_metrics[f"moe_router/layer_{block_idx} std"] = (
+                    router_weight.std().item()
+                )
 
         for hook in self.hooks:
             moe_metrics = {**moe_metrics, **hook.get_stats_dict()}

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -49,6 +49,7 @@ class RouterHook(Hook):
         self.inputs_std = []
         self.expert_bias_abs_mean = []
         self.expert_bias_std = []
+        # NOTE: @goon - the scores abs mean will always be 1 if we have route_norm=True
         self.scores_abs_mean = []
         self.scores_std = []
 

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -30,16 +30,16 @@ class CustomMetricsProcessor(MetricsProcessor):
             for block_idx, transformer_block in model_part.layers.items():
                 if not transformer_block.moe_enabled:
                     continue
-                moe_metrics[
-                    f"moe_entropy/layer_{block_idx}"
-                ] = self.get_normalized_entropy(transformer_block)
+                moe_metrics[f"moe_entropy/layer_{block_idx}"] = (
+                    self.get_normalized_entropy(transformer_block)
+                )
                 if (
                     n_expert_groups := model_part.model_args.moe_args.n_expert_groups
                 ) > 1:
-                    moe_metrics[
-                        f"moe_group_entropy/layer_{block_idx}"
-                    ] = self.get_expert_group_normalized_group_entropy(
-                        transformer_block, n_expert_groups
+                    moe_metrics[f"moe_group_entropy/layer_{block_idx}"] = (
+                        self.get_expert_group_normalized_group_entropy(
+                            transformer_block, n_expert_groups
+                        )
                     )
                 # Reset
                 transformer_block.moe.tokens_per_expert_cumulative.zero_()
@@ -49,15 +49,9 @@ class CustomMetricsProcessor(MetricsProcessor):
                 moe_metrics[f"moe_router/layer_{block_idx} abs mean"] = (
                     router_weight.abs().mean().item()
                 )
-                moe_metrics[
-                    f"moe_router/layer_{block_idx} std"
-                ] = router_weight.std().item()
-                moe_metrics[
-                    f"moe_router/layer_{block_idx} min"
-                ] = router_weight.min().item()
-                moe_metrics[
-                    f"moe_router/layer_{block_idx} max"
-                ] = router_weight.max().item()
+                moe_metrics[f"moe_router/layer_{block_idx} std"] = (
+                    router_weight.std().item()
+                )
 
         return moe_metrics
 

--- a/torchtitan/models/llama3_moe/model/model.py
+++ b/torchtitan/models/llama3_moe/model/model.py
@@ -298,12 +298,6 @@ class VirtualGroupMoE(_CustomMoE):
             raise ValueError(
                 f"{self.moe_args.num_experts=} must be divisible by {self.moe_args.hf_ffn_hidden_dim // self.hidden_dim =}"
             )
-        if self.moe_args.route_scale != self.n_groups:
-            raise ValueError(
-                f"{self.moe_args.route_scale=} must equal {self.moe_args.hf_ffn_hidden_dim // self.hidden_dim =}"
-            )
-        if not self.moe_args.route_norm:
-            raise ValueError(f"{self.moe_args.route_norm=} must be True")
         if self.moe_args.top_k % self.n_groups:
             raise ValueError(
                 f"{self.moe_args.top_k=} must be divisible by {self.moe_args.hf_ffn_hidden_dim // self.hidden_dim =}"
@@ -311,6 +305,19 @@ class VirtualGroupMoE(_CustomMoE):
         if self.moe_args.score_before_experts:
             raise ValueError(
                 f"Virtual group init requires {self.moe_args.score_before_experts=} to be False"
+            )
+
+        # Previously raised ValueErrors on these, but just warning now, as we might want to
+        # experiment with different settings.
+        if self.moe_args.route_scale != self.n_groups:
+            logger.warning(
+                f"{self.moe_args.route_scale=} must equal"
+                f" {self.moe_args.hf_ffn_hidden_dim // self.hidden_dim =}"
+                " for precise VirtualGroupMoE-FFN equivalence"
+            )
+        if not self.moe_args.route_norm:
+            logger.warning(
+                f"{self.moe_args.route_norm=} must be True for precise VirtualGroupMoE-FFN equivalence"
             )
 
     def init_weights(

--- a/torchtitan/models/moe.py
+++ b/torchtitan/models/moe.py
@@ -280,6 +280,7 @@ class TokenChoiceTopKRouter(nn.Module):
         # NOTE: The expert_bias is only used for routing. The gating value
         #       top_scores is still derived from the original scores.
         if expert_bias is not None:
+            # NOTE: @goon - this is probably wrong when n_expert_groups>1
             _, selected_experts_indices = torch.topk(
                 scores + expert_bias, k=self.top_k, dim=1
             )


### PR DESCRIPTION
Add hooks for capturing token router stats, and also loosens some `ValueError` config checks we might want to experiment with.