### PR TITLE
fix: n_expert_groups > 1 with expert_bias

### DIFF
--- a/tests/llama3_moe/test_model.py
+++ b/tests/llama3_moe/test_model.py
@@ -217,3 +217,5 @@ class TestHooks:
                 assert isinstance(v, float)
         for h in hooks:
             h.reset()
+        reset_stats = [h.get_stats_dict() for h in hooks]
+        assert not any(s for s in reset_stats)

--- a/tests/llama3_moe/test_model.py
+++ b/tests/llama3_moe/test_model.py
@@ -17,7 +17,7 @@ from torchtitan.models.llama3_moe import (
     Llama3MoEModelArgs,
     Llama3MoEStateDictAdapter,
 )
-from torchtitan.models.llama3_moe.metrics import RouterHook
+from torchtitan.models.llama3_moe.metrics import MoEHook
 from torchtitan.models.moe import TokenChoiceTopKRouter
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
@@ -204,7 +204,7 @@ class TestHooks:
         hooks = []
         for fqn, module in model.named_modules():
             if isinstance(module, TokenChoiceTopKRouter):
-                hooks.append(RouterHook(module, fqn, parallel_dims=None))
+                hooks.append(MoEHook(module, fqn, parallel_dims=None))
 
         inputs = torch.randint(
             self.vocab_size, size=(self.bsz, self.seqlen), device=self.device

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -7,7 +7,7 @@
 import os
 import time
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, TYPE_CHECKING
 
 import torch
@@ -436,9 +436,15 @@ class MetricsProcessor:
 
         self.logger.log(metrics, step)
 
+        steps_remaining = self.job_config.training.steps - step
+        secs_remaining = steps_remaining / time_end_to_end
+        time_remaining = timedelta(seconds=secs_remaining)
+
         color = self.color
+
         logger.info(
             f"{color.red}step: {step:2}  "
+            f"{color.yellow}time remaining: {time_remaining}"
             f"{color.green}loss: {global_avg_loss:7.4f}  "
             f"{color.orange}grad_norm: {grad_norm:7.4f}  "
             f"{color.turquoise}memory: {device_mem_stats.max_reserved_gib:5.2f}GiB"

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -444,7 +444,7 @@ class MetricsProcessor:
 
         logger.info(
             f"{color.red}step: {step:2}  "
-            f"{color.yellow}time remaining: {time_remaining}"
+            f"{color.yellow}time remaining: {time_remaining}  "
             f"{color.green}loss: {global_avg_loss:7.4f}  "
             f"{color.orange}grad_norm: {grad_norm:7.4f}  "
             f"{color.turquoise}memory: {device_mem_stats.max_reserved_gib:5.2f}GiB"

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -63,6 +63,9 @@ class MoEOverrides:
     top_k_group: int | None = None
     # Custom args
     router_init_std: float | None = None
+    # HACK: @goon - typing as bool alone means that torchtitan expects --moe_overrides.moe_hooks or
+    # --moe_overrides.no_moe_hooks rather than --moe_overrides.moe_hooks True or
+    # --moe_overrides.moe_hooks False. Typing as follows allows a True/False API.
     moe_hooks: bool | None = True
 
 

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -63,7 +63,7 @@ class MoEOverrides:
     top_k_group: int | None = None
     # Custom args
     router_init_std: float | None = None
-    router_hooks: bool = True
+    moe_hooks: bool = True
 
 
 @dataclass

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -63,7 +63,7 @@ class MoEOverrides:
     top_k_group: int | None = None
     # Custom args
     router_init_std: float | None = None
-    moe_hooks: bool = True
+    moe_hooks: bool | None = True
 
 
 @dataclass

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -70,7 +70,7 @@ class MoEHook:
 class CustomMetricsProcessor(MetricsProcessor):
     eps = 1e-10
     # Bad mutable default, but field(default_factory=list) is erroring, maybe b/c of subclassing?
-    hooks: list[Hook] = []
+    hooks: list[MoEHook] = []
 
     @torch.no_grad
     def get_moe_metrics(self) -> dict[str, Any]:

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -51,10 +51,8 @@ class RouterHook(Hook):
         if not isinstance(self.module, TokenChoiceTopKRouter):
             raise ValueError(f"{self.module=} must be a TokenChoiceTopKRouter instance")
         self.module.gate.register_forward_hook(self.gate_hook)
-
         self._stats_dict = defaultdict(list)
 
-        # NOTE: @goon - the scores abs mean will always be 1 if we have route_norm=True
 
     @torch.no_grad
     def gate_hook(self, module: nn.Module, args, output) -> None:
@@ -67,6 +65,7 @@ class RouterHook(Hook):
         scores, _, _ = output
         self._stats_dict["inputs mean"].append(inputs.detach().mean().item())
         self._stats_dict["inputs std"].append(inputs.detach().std().item())
+        # NOTE: @goon - the scores mean will always be 1 if we have route_norm=True
         self._stats_dict["scores_mean"].append(scores.detach().mean().item())
         self._stats_dict["scores std"].append(scores.detach().std().item())
         if expert_bias is not None:

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -30,7 +30,7 @@ class MoEHook:
         self.inputs_abs_mean = []
         if not isinstance(self.moe, MoE):
             raise ValueError(f"{self.moe=} must be a TokenChoiceTopKRouter instance")
-        self.moe.gate.register_forward_hook(self.gate_hook)
+        self.moe.router.gate.register_forward_hook(self.gate_hook)
         self._stats_dict = defaultdict(list)
 
     @torch.no_grad

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -6,7 +6,7 @@
 
 import math
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -80,16 +80,16 @@ class CustomMetricsProcessor(MetricsProcessor):
             for block_idx, transformer_block in model_part.layers.items():
                 if not transformer_block.moe_enabled:
                     continue
-                moe_metrics[f"moe_entropy/layer_{block_idx}"] = (
-                    self.get_normalized_entropy(transformer_block)
-                )
+                moe_metrics[
+                    f"moe_entropy/layer_{block_idx}"
+                ] = self.get_normalized_entropy(transformer_block)
                 if (
                     n_expert_groups := model_part.model_args.moe_args.n_expert_groups
                 ) > 1:
-                    moe_metrics[f"moe_group_entropy/layer_{block_idx}"] = (
-                        self.get_expert_group_normalized_group_entropy(
-                            transformer_block, n_expert_groups
-                        )
+                    moe_metrics[
+                        f"moe_group_entropy/layer_{block_idx}"
+                    ] = self.get_expert_group_normalized_group_entropy(
+                        transformer_block, n_expert_groups
                     )
                 # Reset
                 transformer_block.moe.tokens_per_expert_cumulative.zero_()
@@ -99,9 +99,9 @@ class CustomMetricsProcessor(MetricsProcessor):
                 moe_metrics[f"moe_router/layer_{block_idx} abs mean"] = (
                     router_weight.abs().mean().item()
                 )
-                moe_metrics[f"moe_router/layer_{block_idx} std"] = (
-                    router_weight.std().item()
-                )
+                moe_metrics[
+                    f"moe_router/layer_{block_idx} std"
+                ] = router_weight.std().item()
 
         for hook in self.hooks:
             moe_metrics = {**moe_metrics, **hook.get_stats_dict()}

--- a/torchtitan/models/llama3_moe/model/model.py
+++ b/torchtitan/models/llama3_moe/model/model.py
@@ -272,7 +272,8 @@ class VirtualGroupMoE(_CustomMoE):
 
     the above can be achieved by initializing the weight P_ed = P_rgd so that it is independent of
     g, i.e. P_rgd = Q_rd for some Q_rd, and also taking the k in top_k to be a multiple of G so that
-    entire groups are activated together. The same conclusion also holds for softmax-then-top_k.
+    entire groups are activated together. The same conclusion also holds for softmax-then-top_k, if
+    we also have `route_norm = True`.
     """
 
     name = "virtual_group"

--- a/torchtitan/models/llama3_moe/model/model.py
+++ b/torchtitan/models/llama3_moe/model/model.py
@@ -299,10 +299,6 @@ class VirtualGroupMoE(_CustomMoE):
             raise ValueError(
                 f"{self.moe_args.num_experts=} must be divisible by {self.moe_args.hf_ffn_hidden_dim // self.hidden_dim =}"
             )
-        if self.moe_args.top_k % self.n_groups:
-            raise ValueError(
-                f"{self.moe_args.top_k=} must be divisible by {self.moe_args.hf_ffn_hidden_dim // self.hidden_dim =}"
-            )
         if self.moe_args.score_before_experts:
             raise ValueError(
                 f"Virtual group init requires {self.moe_args.score_before_experts=} to be False"
@@ -319,6 +315,11 @@ class VirtualGroupMoE(_CustomMoE):
         if not self.moe_args.route_norm:
             logger.warning(
                 f"{self.moe_args.route_norm=} must be True for precise VirtualGroupMoE-FFN equivalence"
+            )
+        if self.moe_args.top_k % self.n_groups:
+            logger.warning(
+                f"{self.moe_args.top_k=} must be divisible by {self.moe_args.hf_ffn_hidden_dim // self.hidden_dim =}"
+                " for precise VirtualGroupMoE-FFN equivalence"
             )
 
     def init_weights(

--- a/torchtitan/models/llama3_moe/model/model.py
+++ b/torchtitan/models/llama3_moe/model/model.py
@@ -330,7 +330,6 @@ class VirtualGroupMoE(_CustomMoE):
 
     def post_init(self) -> None:
         if self.n_groups > 1:
-            logger.info("Apply virtual_group init.")
             with torch.no_grad():
                 # Weight shape: (num_experts, dim) = (n_replicas * n_groups, dim)
                 router_weights = self.router.gate.weight
@@ -359,6 +358,7 @@ class VirtualGroupMoE(_CustomMoE):
                         g=self.n_groups,
                     )
                     self.expert_bias.copy_(replicated_expert_bias)
+            logger.info("Applied virtual_group init.")
 
 
 def get_moe_impl_cls(name: str | None = None) -> type[MoE]:

--- a/torchtitan/models/moe.py
+++ b/torchtitan/models/moe.py
@@ -284,7 +284,6 @@ class TokenChoiceTopKRouter(nn.Module):
         # NOTE: The expert_bias is only used for routing. The gating value
         #       top_scores is still derived from the original scores.
         if expert_bias is not None:
-            # NOTE: @goon - this is probably wrong when n_expert_groups>1
             biased_scores = scores + expert_bias
             if score_mask is not None:
                 biased_scores = biased_scores.masked_fill(~score_mask.bool(), 0.0)

--- a/torchtitan/models/moe.py
+++ b/torchtitan/models/moe.py
@@ -253,10 +253,12 @@ class TokenChoiceTopKRouter(nn.Module):
             # 2) Zero out everything except the top_k groups with k=top_k_group
 
             # NOTE: @goon - need to use the biased scores for choosing the groups
-            temp_scores = scores + expert_bias if expert_bias is not None else scores
+            maybe_biased_scores = (
+                scores + expert_bias if expert_bias is not None else scores
+            )
             group_scores = (
-                temp_scores.view(
-                    temp_scores.shape[0], self.moe_args.n_expert_groups, -1
+                maybe_biased_scores.view(
+                    maybe_biased_scores.shape[0], self.moe_args.n_expert_groups, -1
                 )
                 .max(dim=-1)
                 .values
@@ -276,14 +278,18 @@ class TokenChoiceTopKRouter(nn.Module):
                 .reshape(scores.shape[0], -1)
             )
             scores = scores.masked_fill(~score_mask.bool(), 0.0)
+        else:
+            score_mask = None
 
         # NOTE: The expert_bias is only used for routing. The gating value
         #       top_scores is still derived from the original scores.
         if expert_bias is not None:
             # NOTE: @goon - this is probably wrong when n_expert_groups>1
-            _, selected_experts_indices = torch.topk(
-                scores + expert_bias, k=self.top_k, dim=1
-            )
+            biased_scores = scores + expert_bias
+            if score_mask is not None:
+                biased_scores = biased_scores.masked_fill(~score_mask.bool(), 0.0)
+
+            _, selected_experts_indices = torch.topk(biased_scores, k=self.top_k, dim=1)
             top_scores = scores.gather(dim=1, index=selected_experts_indices)
         else:
             top_scores, selected_experts_indices = torch.topk(


### PR DESCRIPTION
Fixes known TODO affecting `n_expert_groups>1` path when `expert_bias` is non-trivial.  

Accidentally also pulled in moe hook refactors, as well.