### PR TITLE
moe_reshard_after_forward and small edits

### DIFF
--- a/tests/llama3_moe/test_dist.py
+++ b/tests/llama3_moe/test_dist.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 
 import pytest
 import torch
-import torch.distributed as dist
 from dtest import DTest
 
 from torchtitan.components.checkpoint import CheckpointManager, ModelWrapper
@@ -24,20 +23,53 @@ from torchtitan.models.llama3_moe import (
     TransformingHuggingFaceStorageReader,
 )
 from torchtitan.models.moe import MoE, MoEArgs
+from transformers import AutoTokenizer
+
+BITTER_LESSON = """
+The biggest lesson that can be read from 70 years of AI research is that general methods that leverage
+computation are ultimately the most effective, and by a large margin. The ultimate reason for this is
+Moore's law, or rather its generalization of continued exponentially falling cost per unit of
+computation. Most AI research has been conducted as if the computation available to the agent were
+constant (in which case leveraging human knowledge would be one of the only ways to improve
+performance) but, over a slightly longer time than a typical research project, massively more
+computation inevitably becomes available. Seeking an improvement that makes a difference in the
+shorter term, researchers seek to leverage their human knowledge of the domain, but the only thing
+that matters in the long run is the leveraging of computation. These two need not run counter to each
+other, but in practice they tend to. Time spent on one is time not spent on the other. There are
+psychological commitments to investment in one approach or the other. And the human-knowledge
+approach tends to complicate methods in ways that make them less suited to taking advantage of
+general methods leveraging computation.  There were many examples of AI researchers' belated
+learning of this bitter lesson, and it is instructive to review some of the most prominent.
+"""
+ALICE = """
+  Alice was beginning to get very tired of sitting by her sister
+on the bank, and of having nothing to do:  once or twice she had
+peeped into the book her sister was reading, but it had no
+pictures or conversations in it, `and what is the use of a book,'
+thought Alice `without pictures or conversation?'
+
+  So she was considering in her own mind (as well as she could,
+for the hot day made her feel very sleepy and stupid), whether
+the pleasure of making a daisy-chain would be worth the trouble
+of getting up and picking the daisies, when suddenly a White
+Rabbit with pink eyes ran close by her.
+"""
 
 
 class TestHFReader(DTest):
     hf_assets_path = "/gpfs/goon/models/Llama-3.2-3B-no-tied-weights/"
     seqlen = 64
     bsz = 1
+    tok = AutoTokenizer.from_pretrained(hf_assets_path)
+    tol = 1e-1
+
     """
     Test loading correctness
     """
 
-    @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
-    def test_non_moe_load_equivalence(self, sharding: str) -> None:
+    def test_custom_load_equivalence(self) -> None:
         """
-        Test e2e equivlance on the full 3B model.
+        Test e2e equivalence of loading with CustomCheckpointManager.
         """
         model_args = llama3_moe_configs["3B"]
         job_config = Llama3MoEJobConfig()
@@ -48,13 +80,14 @@ class TestHFReader(DTest):
             model = Llama3MoE(model_args)
         model_copy = deepcopy(model)
 
+        # FSDP
         parallel_dims = ParallelDims(
             dp_shard=-1,
             dp_replicate=1,
             cp=1,
             tp=1,
             pp=1,
-            ep=self.world_size if sharding == "ep" else 1,
+            ep=1,
             etp=1,
             world_size=self.world_size,
         )
@@ -86,73 +119,10 @@ class TestHFReader(DTest):
             model_parts=[model_copy], **ckpt_kwargs
         )
         custom_checkpointer.load()
-        torch.manual_seed(42 + dist.get_rank())
-        with torch.no_grad():
-            inputs = torch.randint(
-                model_args.vocab_size, size=(self.bsz, self.seqlen), device=self.device
-            )
-            out = model(inputs)
-            out_copy = model_copy(inputs)
-            torch.testing.assert_close(out, out_copy)
-
-    @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
-    def test_small_non_moe_load_equivalence(self, sharding: str) -> None:
-        """
-        Test equivalence (and that load succeeds) on a truncated version of the model with fewer
-        layers.
-        """
-        model_args = llama3_moe_configs["3B_2layer"]
-        job_config = Llama3MoEJobConfig()
-        job_config.checkpoint.enable = True
-        job_config.checkpoint.initial_load_in_hf = True
-        job_config.model.hf_assets_path = self.hf_assets_path
-        with torch.device("meta"):
-            model = Llama3MoE(model_args)
-        model_copy = deepcopy(model)
-
-        parallel_dims = ParallelDims(
-            dp_shard=-1,
-            dp_replicate=1,
-            cp=1,
-            tp=1,
-            pp=1,
-            ep=self.world_size if sharding == "ep" else 1,
-            etp=1,
-            world_size=self.world_size,
+        inputs = self.tok(BITTER_LESSON, return_tensors="pt")["input_ids"].to(
+            self.device
         )
-
-        model = parallelize_llama_moe(model, parallel_dims, job_config)
-        model_copy = parallelize_llama_moe(model_copy, parallel_dims, job_config)
-
-        model.to_empty(device=self.device)
-        model_copy.to_empty(device=self.device)
         with torch.no_grad():
-            model.init_weights(buffer_device=None)
-            model_copy.init_weights(buffer_device=None)
-
-        ckpt_kwargs = {
-            "dataloader": None,
-            "optimizers": None,  # HACK: @goon - ok to set to None for initial load
-            "lr_schedulers": None,  # HACK: @goon - ok to set to None for initial load
-            "states": {"train_state": self},
-            "checkpoint_config": job_config.checkpoint,
-            "sd_adapter": Llama3MoEStateDictAdapter(model_args, self.hf_assets_path),
-            "base_folder": "",
-            "ft_manager": None,
-        }
-
-        checkpointer = CheckpointManager(model_parts=[model], **ckpt_kwargs)
-        checkpointer.load()
-
-        custom_checkpointer = CustomCheckpointManager(
-            model_parts=[model_copy], **ckpt_kwargs
-        )
-        custom_checkpointer.load()
-        torch.manual_seed(42 + dist.get_rank())
-        with torch.no_grad():
-            inputs = torch.randint(
-                model_args.vocab_size, size=(self.bsz, self.seqlen), device=self.device
-            )
             out = model(inputs)
             out_copy = model_copy(inputs)
             torch.testing.assert_close(out, out_copy)
@@ -160,8 +130,7 @@ class TestHFReader(DTest):
     @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
     def test_small_moe_load_replicate_transform(self, sharding: str) -> None:
         """
-        Test  (and that load succeeds) on a truncated version of the model with fewer
-        layers.
+        Test that Custom loading succeeds with a MoE layer. Uses a truncated model.
         """
         model_args = llama3_moe_configs["3B_2layer"]
         model_args_moe = llama3_moe_configs["3B_2layer_halfmoe"]
@@ -252,6 +221,199 @@ class TestHFReader(DTest):
                     for w_moe_expert_shard in w_moe:
                         torch.testing.assert_close(w, w_moe_expert_shard)
 
+    @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
+    def test_small_moe_load_replicate_transform_vg(self, sharding: str) -> None:
+        """
+        Test that custom loading succeeds and that virtual group init works.
+        """
+        model_args = llama3_moe_configs["3B_2layer"]
+        model_args_moe = llama3_moe_configs["3B_2layer_halfmoe_vg"]
+        job_config = Llama3MoEJobConfig()
+        job_config.checkpoint.enable = True
+        job_config.checkpoint.initial_load_in_hf = True
+        job_config.model.hf_assets_path = self.hf_assets_path
+
+        with torch.device("meta"):
+            model = Llama3MoE(model_args)
+            model_moe = Llama3MoE(model_args_moe)
+
+        parallel_dims = ParallelDims(
+            dp_shard=-1,
+            dp_replicate=1,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=self.world_size if sharding == "ep" else 1,
+            etp=1,
+            world_size=self.world_size,
+        )
+
+        model = parallelize_llama_moe(model, parallel_dims, job_config)
+        model_moe = parallelize_llama_moe(model_moe, parallel_dims, job_config)
+
+        model.to_empty(device=self.device)
+        model_moe.to_empty(device=self.device)
+        with torch.no_grad():
+            model.init_weights(buffer_device=None)
+            model_moe.init_weights(buffer_device=None)
+
+        # Sanity checks:
+        assert not any(isinstance(m, MoE) for m in model.modules())
+        assert any(isinstance(m, MoE) for m in model_moe.modules())
+
+        ckpt_kwargs = {
+            "dataloader": None,
+            "optimizers": None,  # HACK: @goon - ok to set to None for initial load
+            "lr_schedulers": None,  # HACK: @goon - ok to set to None for initial load
+            "states": {"train_state": self},
+            "checkpoint_config": job_config.checkpoint,
+            "base_folder": "",
+            "ft_manager": None,
+        }
+
+        checkpointer = CheckpointManager(
+            model_parts=[model],
+            sd_adapter=Llama3MoEStateDictAdapter(model_args, self.hf_assets_path),
+            **ckpt_kwargs,
+        )
+        checkpointer.load()
+
+        sd_adapter_moe = Llama3MoEStateDictAdapter(model_args_moe, self.hf_assets_path)
+        custom_checkpointer = CustomCheckpointManager(
+            hf_storage_reader=TransformingHuggingFaceStorageReader,
+            hf_storage_reader_kwargs={
+                "transform_fn": get_hf_weight_transform_cls("replicate")(
+                    model_args=model_args_moe,
+                    hf_to_titan_fqn_map=sd_adapter_moe.from_hf_map,
+                ),
+                "state_dict": ModelWrapper([model_moe]).state_dict(),
+                "sd_adapter": sd_adapter_moe,
+            },
+            model_parts=[model_moe],
+            sd_adapter=sd_adapter_moe,
+            **ckpt_kwargs,
+        )
+        custom_checkpointer.load()
+
+        inputs = self.tok(BITTER_LESSON, return_tensors="pt")["input_ids"].to(
+            self.device
+        )
+        with torch.no_grad():
+            out = model(inputs)
+            out_copy = model_moe(inputs)
+            torch.testing.assert_close(out, out_copy, atol=self.tol, rtol=self.tol)
+
+    @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
+    def test_moe_load_replicate_transform_vg(self, sharding: str) -> None:
+        """
+        For inspecting the 3B model with MoE layers.
+        """
+        model_args = llama3_moe_configs["3B"]
+        llama_3b_hidden_dim = 8192
+        n_replicas = n_groups = 2
+        model_args_moe = deepcopy(model_args)
+        moe_args = MoEArgs(
+            num_experts=n_replicas * n_groups,
+            num_shared_experts=0,
+            score_func="softmax",
+            route_norm=True,
+            score_before_experts=False,
+            top_k=n_groups,
+            route_scale=n_groups,
+            hf_ffn_hidden_dim=llama_3b_hidden_dim,  # Must specify for virtual_group router init!
+        )
+        model_args_moe.moe_args = moe_args
+        model_args_moe.moe_inter_dim = llama_3b_hidden_dim // n_groups
+        # # Second to last layer MoE
+        # model_args_moe.is_moe_list = (
+        #     [False for _ in range(model_args.n_layers - 2)] + [True] + [False]
+        # )
+        # First and last to last layers MoE
+        model_args_moe.is_moe_list = (
+            [True] + [False for _ in range(model_args.n_layers - 2)] + [True]
+        )
+        model_args_moe.custom_moe_impl = "virtual_group"
+
+        job_config = Llama3MoEJobConfig()
+        job_config.checkpoint.enable = True
+        job_config.checkpoint.initial_load_in_hf = True
+        job_config.model.hf_assets_path = self.hf_assets_path
+
+        with torch.device("meta"):
+            model = Llama3MoE(model_args)
+            model_moe = Llama3MoE(model_args_moe)
+
+        parallel_dims = ParallelDims(
+            dp_shard=-1,
+            dp_replicate=1,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=self.world_size if sharding == "ep" else 1,
+            etp=1,
+            world_size=self.world_size,
+        )
+
+        model = parallelize_llama_moe(model, parallel_dims, job_config)
+        model_moe = parallelize_llama_moe(model_moe, parallel_dims, job_config)
+
+        model.to_empty(device=self.device)
+        model_moe.to_empty(device=self.device)
+        with torch.no_grad():
+            model.init_weights(buffer_device=None)
+            model_moe.init_weights(buffer_device=None)
+
+        # Sanity checks:
+        assert not any(isinstance(m, MoE) for m in model.modules())
+        assert any(isinstance(m, MoE) for m in model_moe.modules())
+
+        ckpt_kwargs = {
+            "dataloader": None,
+            "optimizers": None,  # HACK: @goon - ok to set to None for initial load
+            "lr_schedulers": None,  # HACK: @goon - ok to set to None for initial load
+            "states": {"train_state": self},
+            "checkpoint_config": job_config.checkpoint,
+            "base_folder": "",
+            "ft_manager": None,
+        }
+
+        checkpointer = CheckpointManager(
+            model_parts=[model],
+            sd_adapter=Llama3MoEStateDictAdapter(model_args, self.hf_assets_path),
+            **ckpt_kwargs,
+        )
+        checkpointer.load()
+
+        sd_adapter_moe = Llama3MoEStateDictAdapter(model_args_moe, self.hf_assets_path)
+        custom_checkpointer = CustomCheckpointManager(
+            hf_storage_reader=TransformingHuggingFaceStorageReader,
+            hf_storage_reader_kwargs={
+                "transform_fn": get_hf_weight_transform_cls("replicate")(
+                    model_args=model_args_moe,
+                    hf_to_titan_fqn_map=sd_adapter_moe.from_hf_map,
+                ),
+                "state_dict": ModelWrapper([model_moe]).state_dict(),
+                "sd_adapter": sd_adapter_moe,
+            },
+            model_parts=[model_moe],
+            sd_adapter=sd_adapter_moe,
+            **ckpt_kwargs,
+        )
+        custom_checkpointer.load()
+
+        bitter_inputs = self.tok(BITTER_LESSON, return_tensors="pt")["input_ids"].to(
+            self.device
+        )
+        alice_inputs = self.tok(ALICE, return_tensors="pt")["input_ids"].to(self.device)
+        # Alice inputs are shorter
+        inputs = torch.cat(
+            [bitter_inputs[:, : alice_inputs.shape[1]], alice_inputs], dim=0
+        )
+        with torch.no_grad():
+            out = model(inputs)
+            out_copy = model_moe(inputs)
+            torch.testing.assert_close(out, out_copy, atol=self.tol, rtol=self.tol)
+
 
 class TestImpls(DTest):
     hf_assets_path = "/gpfs/goon/models/Llama-3.2-3B-no-tied-weights/"
@@ -263,7 +425,8 @@ class TestImpls(DTest):
     Test impl correctness
     """
 
-    @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
+    # @pytest.mark.parametrize("sharding", ["fsdp", "ep"])
+    @pytest.mark.parametrize("sharding", ["ep"])
     def test_basic_replication(self, sharding: str) -> None:
         """
         Test that the dense and MoE models have the same output with FFN weight replication.

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -437,7 +437,7 @@ class MetricsProcessor:
         self.logger.log(metrics, step)
 
         steps_remaining = self.job_config.training.steps - step
-        secs_remaining = steps_remaining / time_end_to_end
+        secs_remaining = steps_remaining * time_end_to_end
         time_remaining = timedelta(seconds=secs_remaining)
 
         color = self.color

--- a/torchtitan/experiments/llama4/infra/parallelize.py
+++ b/torchtitan/experiments/llama4/infra/parallelize.py
@@ -280,6 +280,7 @@ def apply_fsdp(
     pp_enabled: bool,
     cpu_offload: bool = False,
     reshard_after_forward_policy: str = "default",
+    moe_reshard_after_forward: bool | None = None,
     ep_degree: int = 1,
     dp_mod_ep_mesh: DeviceMesh | None = None,
     gradient_divide_factor: int | None = None,
@@ -320,6 +321,9 @@ def apply_fsdp(
                 f"Invalid reshard_after_forward_policy: {reshard_after_forward_policy}."
             )
 
+    if moe_reshard_after_forward is None:
+        moe_reshard_after_forward = reshard_after_forward
+
     if model.tok_embeddings is not None:
         fully_shard(
             model.tok_embeddings,
@@ -353,7 +357,7 @@ def apply_fsdp(
             fully_shard(
                 transformer_block.moe.experts,
                 **fsdp_mod_ep_config,
-                reshard_after_forward=reshard_after_forward,
+                reshard_after_forward=moe_reshard_after_forward,
                 shard_placement_fn=_experts_shard_placement_fn,
             )
 

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -159,7 +159,7 @@ llama3_moe_configs = {
         ),
         rope_scaling_args=llama_3p2_3b_rope_cfg,
     ),
-    # NOTE: @goon - the 3B_2layer and 3B_2layer_halfmoe models are used in
+    # NOTE: @goon - the two-layer cfgs are used in
     # torchtitan/tests/llama3_moe/test_dist.py, do not delete!
     #
     "3B_2layer": Llama3MoEModelArgs(
@@ -182,6 +182,7 @@ llama3_moe_configs = {
         ),
         rope_scaling_args=llama_3p2_3b_rope_cfg,
     ),
+    # See VirtualGroupMoE for necessary cfg requirements for virtual_group init.
     "3B_2layer_halfmoe": Llama3MoEModelArgs(
         dim=3072,
         moe_inter_dim=8192,
@@ -192,20 +193,22 @@ llama3_moe_configs = {
         multiple_of=256,
         rope_theta=500000,
         moe_args=MoEArgs(
-            num_experts=8,
+            num_experts=4,
             num_shared_experts=0,
             score_func="softmax",
             route_norm=True,
             score_before_experts=False,
-            top_k=2,
+            top_k=4,
+            route_scale=4,  # Must have route_scale = top_k; see [Virtual Group Initialization].
+            hf_ffn_hidden_dim=8192,  # Must specify for virtual_group router init!
         ),
         is_moe_list=[False, True],
+        custom_moe_impl="virtual_group",  # Must specify for virtual_group router init!
         rope_scaling_args=llama_3p2_3b_rope_cfg,
     ),
-    # See VirtualGroupMoE for necessary cfg requirements for virtual_group init.
-    "3B_2layer_halfmoe_finegrained": Llama3MoEModelArgs(
+    "3B_2layer_halfmoe_vg": Llama3MoEModelArgs(
         dim=3072,
-        moe_inter_dim=8192 // 2,
+        moe_inter_dim=8192 // 2,  # Two groups per vg  replica
         n_layers=2,
         n_heads=24,
         n_kv_heads=8,
@@ -213,7 +216,7 @@ llama3_moe_configs = {
         multiple_of=256,
         rope_theta=500000,
         moe_args=MoEArgs(
-            num_experts=8 * 2,
+            num_experts=4,  # 2 vg replicas, each w/ two experts
             num_shared_experts=0,
             score_func="softmax",
             route_norm=True,

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -67,6 +67,7 @@ class MoEOverrides:
     # --moe_overrides.no_moe_hooks rather than --moe_overrides.moe_hooks True or
     # --moe_overrides.moe_hooks False. Typing as follows allows a True/False API.
     moe_hooks: bool | None = True
+    moe_reshard_after_forward: bool | None = True
 
 
 @dataclass

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -45,7 +45,7 @@ class MoEHook:
         self._stats_dict["inputs mean"].append(inputs.detach().mean().item())
         self._stats_dict["inputs std"].append(inputs.detach().std().item())
         # NOTE: @goon - the scores mean will always be 1 if we have route_norm=True
-        self._stats_dict["scores_mean"].append(scores.detach().mean().item())
+        self._stats_dict["scores mean"].append(scores.detach().mean().item())
         self._stats_dict["scores std"].append(scores.detach().std().item())
         if expert_bias is not None:
             self._stats_dict["expert bias mean"].append(

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -96,11 +96,11 @@ class CustomMetricsProcessor(MetricsProcessor):
                 router_weight = transformer_block.moe.router.gate.weight
                 if isinstance(router_weight, DTensor):
                     router_weight = router_weight.full_tensor()
-                moe_metrics[f"moe_router/layer_{block_idx} abs mean"] = (
+                moe_metrics[f"moe_router_weight/layer_{block_idx} abs mean"] = (
                     router_weight.abs().mean().item()
                 )
                 moe_metrics[
-                    f"moe_router/layer_{block_idx} std"
+                    f"moe_router_weight/layer_{block_idx} std"
                 ] = router_weight.std().item()
 
         for hook in self.hooks:

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -6,7 +6,7 @@
 
 import math
 from collections import defaultdict
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
@@ -35,31 +35,29 @@ class MoEHook:
 
     @torch.no_grad
     def gate_hook(self, module: nn.Module, args, output) -> None:
-        self._stats_dict["gate scores mean"].append(output.detach().mean().item())
-        self._stats_dict["gate scores std"].append(output.detach().std().item())
+        self._stats_dict["gate scores mean"].append(output.detach().mean())
+        self._stats_dict["gate scores std"].append(output.detach().std())
 
     @torch.no_grad
     def router_hook(self, module: nn.Module, args, output) -> None:
         inputs, expert_bias = args
         scores, _, _ = output
-        self._stats_dict["inputs mean"].append(inputs.detach().mean().item())
-        self._stats_dict["inputs std"].append(inputs.detach().std().item())
+        self._stats_dict["inputs mean"].append(inputs.detach().mean())
+        self._stats_dict["inputs std"].append(inputs.detach().std())
         # NOTE: @goon - the scores mean will always be 1 if we have route_norm=True
-        self._stats_dict["scores mean"].append(scores.detach().mean().item())
-        self._stats_dict["scores std"].append(scores.detach().std().item())
+        self._stats_dict["scores mean"].append(scores.detach().mean())
+        self._stats_dict["scores std"].append(scores.detach().std())
         if expert_bias is not None:
-            self._stats_dict["expert bias mean"].append(
-                expert_bias.detach().mean().item()
-            )
-            self._stats_dict["expert bias std"].append(
-                expert_bias.detach().std().item()
-            )
+            self._stats_dict["expert bias mean"].append(expert_bias.detach().mean())
+            self._stats_dict["expert bias std"].append(expert_bias.detach().std())
 
     def get_stats_dict(self) -> dict[str, float]:
         stats_dict = {}
         for k, v in self._stats_dict.items():
             if v:
-                stats_dict[f"moe_router_hook/{self.fqn} {k}"] = sum(v) / len(v)
+                stats_dict[f"moe_router_hook/{self.fqn} {k}"] = (
+                    torch.stack(v).mean().item()
+                )
         return stats_dict
 
     def reset(self) -> None:
@@ -80,16 +78,16 @@ class CustomMetricsProcessor(MetricsProcessor):
             for block_idx, transformer_block in model_part.layers.items():
                 if not transformer_block.moe_enabled:
                     continue
-                moe_metrics[
-                    f"moe_entropy/layer_{block_idx}"
-                ] = self.get_normalized_entropy(transformer_block)
+                moe_metrics[f"moe_entropy/layer_{block_idx}"] = (
+                    self.get_normalized_entropy(transformer_block)
+                )
                 if (
                     n_expert_groups := model_part.model_args.moe_args.n_expert_groups
                 ) > 1:
-                    moe_metrics[
-                        f"moe_group_entropy/layer_{block_idx}"
-                    ] = self.get_expert_group_normalized_group_entropy(
-                        transformer_block, n_expert_groups
+                    moe_metrics[f"moe_group_entropy/layer_{block_idx}"] = (
+                        self.get_expert_group_normalized_group_entropy(
+                            transformer_block, n_expert_groups
+                        )
                     )
                 # Reset
                 transformer_block.moe.tokens_per_expert_cumulative.zero_()
@@ -99,9 +97,9 @@ class CustomMetricsProcessor(MetricsProcessor):
                 moe_metrics[f"moe_router_weight/layer_{block_idx} abs mean"] = (
                     router_weight.abs().mean().item()
                 )
-                moe_metrics[
-                    f"moe_router_weight/layer_{block_idx} std"
-                ] = router_weight.std().item()
+                moe_metrics[f"moe_router_weight/layer_{block_idx} std"] = (
+                    router_weight.std().item()
+                )
 
         for hook in self.hooks:
             moe_metrics = {**moe_metrics, **hook.get_stats_dict()}

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -6,7 +6,7 @@
 
 import math
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -78,16 +78,16 @@ class CustomMetricsProcessor(MetricsProcessor):
             for block_idx, transformer_block in model_part.layers.items():
                 if not transformer_block.moe_enabled:
                     continue
-                moe_metrics[f"moe_entropy/layer_{block_idx}"] = (
-                    self.get_normalized_entropy(transformer_block)
-                )
+                moe_metrics[
+                    f"moe_entropy/layer_{block_idx}"
+                ] = self.get_normalized_entropy(transformer_block)
                 if (
                     n_expert_groups := model_part.model_args.moe_args.n_expert_groups
                 ) > 1:
-                    moe_metrics[f"moe_group_entropy/layer_{block_idx}"] = (
-                        self.get_expert_group_normalized_group_entropy(
-                            transformer_block, n_expert_groups
-                        )
+                    moe_metrics[
+                        f"moe_group_entropy/layer_{block_idx}"
+                    ] = self.get_expert_group_normalized_group_entropy(
+                        transformer_block, n_expert_groups
                     )
                 # Reset
                 transformer_block.moe.tokens_per_expert_cumulative.zero_()
@@ -97,9 +97,9 @@ class CustomMetricsProcessor(MetricsProcessor):
                 moe_metrics[f"moe_router_weight/layer_{block_idx} abs mean"] = (
                     router_weight.abs().mean().item()
                 )
-                moe_metrics[f"moe_router_weight/layer_{block_idx} std"] = (
-                    router_weight.std().item()
-                )
+                moe_metrics[
+                    f"moe_router_weight/layer_{block_idx} std"
+                ] = router_weight.std().item()
 
         for hook in self.hooks:
             moe_metrics = {**moe_metrics, **hook.get_stats_dict()}

--- a/torchtitan/models/moe.py
+++ b/torchtitan/models/moe.py
@@ -544,8 +544,7 @@ class MoE(MoEOld):
         bs, slen, dim = x.shape
         x = x.view(-1, dim)
 
-        # top_scores shape (bs*slen, top_k)
-        # selected_experts_indices shape (bs*slen, top_k)
+        # top_scores and selected_experts_indices shape (bs*slen, top_k)
         # num_tokens_per_expert shape (num_experts,)
         (
             top_scores,
@@ -561,7 +560,7 @@ class MoE(MoEOld):
         with torch.no_grad():
             self.tokens_per_expert.add_(num_tokens_per_expert)
 
-        # top_scores and token_indices_experts_sorted shape (bs*slen*top_k,)
+        # top_scores_experts_sorted and token_indices_experts_sorted shape (bs*slen*top_k,)
         # num_tokens_per_expert shape (num_experts,)
         # NOTE: the reason we need to compute num_tokens_per_expert again is:
         #       1st computation in router is to update self.tokens_per_expert
@@ -592,21 +591,27 @@ class MoE(MoEOld):
         # to "implicitly" overlap the shared expert compute with token combine communication
         out = self.shared_experts(x) if self.shared_experts is not None else None
 
+        # Unsort routed outputs
+        routed_output_unsorted = torch.zeros(
+            (bs * slen * self.router.top_k, dim),
+            dtype=routed_output.dtype,
+            device=routed_output.device,
+        )
+        routed_output_unsorted[token_indices_experts_sorted] = routed_output
+        routed_output_unsorted = routed_output_unsorted.reshape(
+            -1, self.router.top_k, dim
+        )
         if not self.score_before_experts:
-            # Unsort scores and routed outputs. Also save some allocations: store unsorted scores
-            # and outputs in top_scores and routed_input, respectively.
-            top_scores = top_scores.flatten()
-            top_scores[token_indices_experts_sorted] = top_scores_experts_sorted
-            routed_input[token_indices_experts_sorted] = routed_output
-            routed_input = routed_input.reshape(-1, self.router.top_k, dim)
-            top_scores = top_scores.reshape(-1, 1, self.router.top_k)
             out_experts = (
-                torch.bmm(top_scores, routed_input.float()).to(x.dtype).squeeze(1)
+                torch.bmm(
+                    top_scores.reshape(-1, 1, self.router.top_k),
+                    routed_output_unsorted.float(),
+                )
+                .to(x.dtype)
+                .squeeze(1)
             )
         else:
-            # Unsort routed outputs and save an allocation: store unsorted outputs in routed_input
-            routed_input[token_indices_experts_sorted] = routed_output
-            out_experts = routed_input.reshape(-1, self.router.top_k, dim).sum(dim=1)
+            out_experts = routed_output_unsorted.sum(dim=1)
 
         if out is None:
             return out_experts.reshape(bs, slen, dim)


### PR DESCRIPTION
Adds a `MoEOverrides.moe_reshard_after_forward` option, giving explicit control over whether to use ZeRO 2 or 3 on the routed experts. Also cleans up some metric names, reduces CUDA syncs for metrics `.item()` calls and fiddles with the tests.