### PR TITLE
fix: moe no-reshard, and add expert lr and tests

### DIFF
--- a/tests/llama3_moe/test_dist.py
+++ b/tests/llama3_moe/test_dist.py
@@ -631,3 +631,50 @@ class TestImpls(DTest):
             out = model(inputs)
             out_moe = model_moe(inputs)
             torch.testing.assert_close(out, out_moe, atol=self.atol, rtol=self.rtol)
+
+
+class TestMoENoReshard(DTest):
+    seqlen = 64
+    bsz = 1
+    atol = 1e-1
+    rtol = 1e-1
+
+    @pytest.mark.parametrize("sharding", ["ep"])
+    @pytest.mark.parametrize("moe_reshard_after_forward", [True, False])
+    def test_no_reshard_option(
+        self, sharding: str, moe_reshard_after_forward: bool
+    ) -> None:
+        """
+        Test that the dense and MoE models have the same output with FFN weight replication.
+        """
+        model_args_moe = llama3_moe_configs["3B_2layer_halfmoe"]
+        job_config = Llama3MoEJobConfig()
+        job_config.moe_overrides.moe_reshard_after_forward = moe_reshard_after_forward
+        with torch.device("meta"):
+            model_moe = Llama3MoE(model_args_moe)
+
+        parallel_dims = ParallelDims(
+            dp_shard=-1,
+            dp_replicate=1,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=self.world_size if sharding == "ep" else 1,
+            etp=1,
+            world_size=self.world_size,
+        )
+
+        model_moe = parallelize_llama_moe(model_moe, parallel_dims, job_config)
+
+        model_moe.to_empty(device=self.device)
+        with torch.no_grad():
+            model_moe.init_weights(buffer_device=None)
+
+        routed_experts = model_moe.layers["1"].moe.experts
+        post_forward_mesh_info = (
+            routed_experts._get_fsdp_state()._fsdp_param_group.post_forward_mesh_info
+        )
+        if moe_reshard_after_forward:
+            assert post_forward_mesh_info is not None
+        else:
+            assert post_forward_mesh_info is None

--- a/tests/llama3_moe/test_dist.py
+++ b/tests/llama3_moe/test_dist.py
@@ -9,21 +9,21 @@ from copy import deepcopy
 import pytest
 import torch
 from dtest import DTest
+from transformers import AutoTokenizer
 
 from torchtitan.components.checkpoint import CheckpointManager, ModelWrapper
 from torchtitan.distributed import ParallelDims
 from torchtitan.models.llama3_moe import (
     CustomCheckpointManager,
-    get_hf_weight_transform_cls,
-    llama3_moe_configs,
     Llama3MoE,
     Llama3MoEJobConfig,
     Llama3MoEStateDictAdapter,
-    parallelize_llama_moe,
     TransformingHuggingFaceStorageReader,
+    get_hf_weight_transform_cls,
+    llama3_moe_configs,
+    parallelize_llama_moe,
 )
 from torchtitan.models.moe import MoE, MoEArgs
-from transformers import AutoTokenizer
 
 BITTER_LESSON = """
 The biggest lesson that can be read from 70 years of AI research is that general methods that leverage

--- a/tests/llama3_moe/test_dist.py
+++ b/tests/llama3_moe/test_dist.py
@@ -9,21 +9,21 @@ from copy import deepcopy
 import pytest
 import torch
 from dtest import DTest
-from transformers import AutoTokenizer
 
 from torchtitan.components.checkpoint import CheckpointManager, ModelWrapper
 from torchtitan.distributed import ParallelDims
 from torchtitan.models.llama3_moe import (
     CustomCheckpointManager,
+    get_hf_weight_transform_cls,
+    llama3_moe_configs,
     Llama3MoE,
     Llama3MoEJobConfig,
     Llama3MoEStateDictAdapter,
-    TransformingHuggingFaceStorageReader,
-    get_hf_weight_transform_cls,
-    llama3_moe_configs,
     parallelize_llama_moe,
+    TransformingHuggingFaceStorageReader,
 )
 from torchtitan.models.moe import MoE, MoEArgs
+from transformers import AutoTokenizer
 
 BITTER_LESSON = """
 The biggest lesson that can be read from 70 years of AI research is that general methods that leverage

--- a/tests/llama3_moe/test_model.py
+++ b/tests/llama3_moe/test_model.py
@@ -8,19 +8,19 @@
 import pytest
 import torch
 import torch.nn.functional as F
-from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.models.llama3_moe import (
+    llama3_moe_configs,
     Llama3MoE,
     Llama3MoEJobConfig,
     Llama3MoEModelArgs,
     Llama3MoEStateDictAdapter,
-    llama3_moe_configs,
 )
 from torchtitan.models.llama3_moe.metrics import MoEHook
 from torchtitan.models.moe import TokenChoiceTopKRouter
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 TEST_TEXT = """
 The biggest lesson that can be read from 70 years of AI research is that general methods that leverage

--- a/tests/llama3_moe/test_model.py
+++ b/tests/llama3_moe/test_model.py
@@ -8,18 +8,19 @@
 import pytest
 import torch
 import torch.nn.functional as F
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
+import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.models.llama3_moe import (
-    llama3_moe_configs,
     Llama3MoE,
     Llama3MoEJobConfig,
     Llama3MoEModelArgs,
     Llama3MoEStateDictAdapter,
+    llama3_moe_configs,
 )
 from torchtitan.models.llama3_moe.metrics import MoEHook
 from torchtitan.models.moe import TokenChoiceTopKRouter
-from transformers import AutoModelForCausalLM, AutoTokenizer
 
 TEST_TEXT = """
 The biggest lesson that can be read from 70 years of AI research is that general methods that leverage
@@ -219,3 +220,38 @@ class TestHooks:
             h.reset()
         reset_stats = [h.get_stats_dict() for h in hooks]
         assert not any(s for s in reset_stats)
+
+
+class TestOptim:
+    seqlen = 64
+    bsz = 1
+    atol = 1e-1
+    rtol = 1e-1
+
+    def test_per_layer_lrs(self) -> None:
+        model_args_moe = llama3_moe_configs["3B_2layer_halfmoe"]
+        job_config = Llama3MoEJobConfig()
+        lr = 1e-4
+        moe_router_lr = 1e-3
+        routed_expert_lr = 1e-2
+
+        job_config.optimizer.lr = lr
+        job_config.optimizer.moe_router_lr = moe_router_lr
+        job_config.optimizer.routed_expert_lr = routed_expert_lr
+
+        train_spec = train_spec_module.get_train_spec(job_config.model.name)
+        model_moe = Llama3MoE(model_args_moe)
+        optimizers = train_spec.build_optimizers_fn(
+            [model_moe],
+            job_config.optimizer,
+            parallel_dims=None,  # HACK: ok to set to none here.
+            ft_manager=None,
+        )
+        param_groups = optimizers.optimizers[0].param_groups
+        # Not a very detailed test, but good enough.
+        assert len(param_groups) == 3
+        assert set(pg["lr"] for pg in param_groups) == {
+            lr,
+            moe_router_lr,
+            routed_expert_lr,
+        }

--- a/tests/llama3_moe/test_moe.py
+++ b/tests/llama3_moe/test_moe.py
@@ -7,9 +7,9 @@
 
 import torch
 from einops import rearrange
-from triton.testing import do_bench
 
 from torchtitan.models.moe import FeedForward, MoE, MoEArgs, MoEOld
+from triton.testing import do_bench
 
 
 # NOTE: @goon -  torch.testing.assert_close is very strict and hard to pass. Use the more-lenient

--- a/tests/llama3_moe/test_moe.py
+++ b/tests/llama3_moe/test_moe.py
@@ -7,9 +7,9 @@
 
 import torch
 from einops import rearrange
+from triton.testing import do_bench
 
 from torchtitan.models.moe import FeedForward, MoE, MoEArgs, MoEOld
-from triton.testing import do_bench
 
 
 # NOTE: @goon -  torch.testing.assert_close is very strict and hard to pass. Use the more-lenient
@@ -275,36 +275,3 @@ class TestMoE:
             dtype=torch.bfloat16,
         )
         moe(inputs).sum().backward()
-
-
-if __name__ == "__main__":
-    t = TestModel()
-
-    # Collect some accuracy stats
-    moe_old_rel_errs = []
-    moe_rel_errs = []
-    accuracy_iters = 10
-    for idx in range(accuracy_iters):
-        moe_old_rel_err, moe_rel_err = t.test_moe_ffn_equivalence(idx)
-        moe_old_rel_errs.append(moe_old_rel_err)
-        moe_rel_errs.append(moe_rel_err)
-    mean_moe_old_rel_err = torch.tensor(moe_old_rel_errs)
-    mean_moe_rel_err = torch.tensor(moe_rel_errs)
-
-    print(f"\nACCURACY VS FFN: {accuracy_iters} iterations\n")
-    print(f"{mean_moe_old_rel_err.mean()=}, {mean_moe_old_rel_err.std()=}")
-    print(f"{mean_moe_rel_err.mean()=}, {mean_moe_rel_err.std()=}")
-    print(f"{mean_moe_old_rel_err.mean()/mean_moe_rel_err.mean()=}")
-
-    # Perf bsz and seqlen as in torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml
-    perf_seqlen = 4096
-    perf_bsz = 4
-    print(
-        f"\nTRITON BENCH: {perf_seqlen=} {perf_bsz=} warmups={t.perf_warmups} repeats={t.perf_reps}\n"
-    )
-    t.test_perf(bsz=perf_bsz, seqlen=perf_seqlen)
-
-    t.test_moe_old_moe_equivalence(True)
-    print("\nMoEOld AND MoE CLOSE: score_before_experts=True")
-    t.test_moe_old_moe_equivalence(False)
-    print("\nMoEOld AND MoE CLOSE: score_before_experts=False")

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -98,7 +98,7 @@ class OptimizersContainer(Optimizer, Stateful, Generic[T]):
             for module in model.modules():
                 if isinstance(module, TokenChoiceTopKRouter):
                     router_params_set.update(module.parameters())
-                if isinstance(module, GroupedExperts):
+                elif isinstance(module, GroupedExperts):
                     routed_expert_params_set.update(module.parameters())
             non_router_params_set = (
                 all_params_set - router_params_set - routed_expert_params_set

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -21,7 +21,6 @@ from torch.optim import Optimizer
 from torchtitan.components.ft import FTManager, has_torchft
 from torchtitan.config import Optimizer as OptimizerConfig
 from torchtitan.distributed import ParallelDims
-from torchtitan.models.llama3_moe.custom_args import Llama3MoEOptimizer
 from torchtitan.models.moe import GroupedExperts, TokenChoiceTopKRouter
 
 __all__ = [
@@ -298,8 +297,6 @@ def build_optimizers(
         optimizer_config (OptimizerConfig): Optimizer config containing the optimizer name and parameters.
         parallel_dims (ParallelDims): Parallel dimensions for the model.
     """
-    if not isinstance(optimizer_config, Llama3MoEOptimizer):
-        raise ValueError(f"Only Llama3MoEOptimizer cfg classes are suported: {optimizer_config=}")
     optim_in_bwd = optimizer_config.early_step_in_backward
     if optim_in_bwd:
         if parallel_dims.ep_enabled:

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -21,7 +21,8 @@ from torch.optim import Optimizer
 from torchtitan.components.ft import FTManager, has_torchft
 from torchtitan.config import Optimizer as OptimizerConfig
 from torchtitan.distributed import ParallelDims
-from torchtitan.models.moe import TokenChoiceTopKRouter
+from torchtitan.models.llama3_moe.custom_args import Llama3MoEOptimizer
+from torchtitan.models.moe import GroupedExperts, TokenChoiceTopKRouter
 
 __all__ = [
     "OptimizersContainer",
@@ -76,28 +77,39 @@ class OptimizersContainer(Optimizer, Stateful, Generic[T]):
         self.optimizers = []
         self.model_parts = model_parts
         moe_router_lr = optimizer_kwargs.pop("moe_router_lr")
-        if moe_router_lr is None:
-            for model in self.model_parts:
-                params = [p for p in model.parameters() if p.requires_grad]
-                self.optimizers.append(optimizer_cls(params, **optimizer_kwargs))
-                all_params.extend(params)
-        else:
-            non_router_kwargs = optimizer_kwargs.copy()
-            router_kwargs = optimizer_kwargs.copy()
-            router_kwargs["lr"] = moe_router_lr
-            for model in self.model_parts:
-                all_params_set = set(model.parameters())
-                all_params.extend(all_params_set)
-                router_params_set = set()
-                for module in model.modules():
-                    if isinstance(module, TokenChoiceTopKRouter):
-                        router_params_set.update(module.parameters())
-                non_router_params_set = all_params_set - router_params_set
-                arg_list = [
-                    {"params": list(non_router_params_set), **non_router_kwargs},
-                    {"params": list(router_params_set), **router_kwargs},
-                ]
-                self.optimizers.append(optimizer_cls(arg_list))
+        moe_router_lr = (
+            optimizer_kwargs["lr"] if moe_router_lr is None else moe_router_lr
+        )
+        routed_expert_lr = optimizer_kwargs.pop("routed_expert_lr")
+        routed_expert_lr = (
+            optimizer_kwargs["lr"] if routed_expert_lr is None else routed_expert_lr
+        )
+
+        non_router_kwargs = optimizer_kwargs.copy()
+        router_kwargs = optimizer_kwargs.copy()
+        router_kwargs["lr"] = moe_router_lr
+        routed_expert_kwargs = optimizer_kwargs.copy()
+        routed_expert_kwargs["lr"] = routed_expert_lr
+
+        for model in self.model_parts:
+            all_params_set = set(model.parameters())
+            all_params.extend(all_params_set)
+            router_params_set = set()
+            routed_expert_params_set = set()
+            for module in model.modules():
+                if isinstance(module, TokenChoiceTopKRouter):
+                    router_params_set.update(module.parameters())
+                if isinstance(module, GroupedExperts):
+                    routed_expert_params_set.update(module.parameters())
+            non_router_params_set = (
+                all_params_set - router_params_set - routed_expert_params_set
+            )
+            arg_list = [
+                {"params": list(non_router_params_set), **non_router_kwargs},
+                {"params": list(router_params_set), **router_kwargs},
+                {"params": list(routed_expert_params_set), **routed_expert_kwargs},
+            ]
+            self.optimizers.append(optimizer_cls(arg_list))
 
         self._validate_length(len(self.model_parts))
         self._post_init(all_params, optimizer_kwargs)
@@ -286,6 +298,8 @@ def build_optimizers(
         optimizer_config (OptimizerConfig): Optimizer config containing the optimizer name and parameters.
         parallel_dims (ParallelDims): Parallel dimensions for the model.
     """
+    if not isinstance(optimizer_config, Llama3MoEOptimizer):
+        raise ValueError(f"Only Llama3MoEOptimizer cfg classes are suported: {optimizer_config=}")
     optim_in_bwd = optimizer_config.early_step_in_backward
     if optim_in_bwd:
         if parallel_dims.ep_enabled:
@@ -308,6 +322,7 @@ def build_optimizers(
     eps = optimizer_config.eps
     weight_decay = optimizer_config.weight_decay
     moe_router_lr = optimizer_config.moe_router_lr
+    routed_expert_lr = optimizer_config.routed_expert_lr
 
     optim_implementation = optimizer_config.implementation
     assert optim_implementation in ["fused", "foreach", "for-loop"]
@@ -323,6 +338,7 @@ def build_optimizers(
         "fused": fused,
         "foreach": foreach,
         "moe_router_lr": moe_router_lr,
+        "routed_expert_lr": routed_expert_lr,
     }
 
     optimizer_classes = {

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -73,6 +73,7 @@ class MoEOverrides:
 @dataclass
 class Llama3MoEOptimizer(Optimizer):
     moe_router_lr: float | None = None
+    routed_expert_lr: float | None = None
 
 
 @dataclass

--- a/torchtitan/models/llama3_moe/infra/parallelize.py
+++ b/torchtitan/models/llama3_moe/infra/parallelize.py
@@ -10,10 +10,10 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import Replicate, Shard
 from torch.distributed.tensor.parallel import (
     ColwiseParallel,
+    parallelize_module,
     PrepareModuleInput,
     RowwiseParallel,
     SequenceParallel,
-    parallelize_module,
 )
 
 from torchtitan.config import TORCH_DTYPE_MAP
@@ -64,7 +64,9 @@ def parallelize_llama_moe(
     # TODO: TP currently cannot handle uneven seq_len because we set
     #       `use_local_output=True` to use plain Tensors for legacy reasons.
     #       Need to revisit this.
-    assert job_config.training.seq_len % parallel_dims.seq_len_divisor == 0, f"""
+    assert (
+        job_config.training.seq_len % parallel_dims.seq_len_divisor == 0
+    ), f"""
         Sequence length {job_config.training.seq_len} must be divisible by the product of TP degree
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
         """

--- a/torchtitan/models/llama3_moe/infra/parallelize.py
+++ b/torchtitan/models/llama3_moe/infra/parallelize.py
@@ -152,6 +152,7 @@ def parallelize_llama_moe(
             pp_enabled=parallel_dims.pp_enabled,
             cpu_offload=job_config.training.enable_cpu_offload,
             reshard_after_forward_policy=job_config.parallelism.fsdp_reshard_after_forward,
+            moe_reshard_after_forward==job_config.moe_overrides.moe_reshard_after_forward,
             ep_degree=parallel_dims.ep,
             dp_mod_ep_mesh=(
                 world_mesh[tuple(dp_mod_ep_mesh_dim_names)]

--- a/torchtitan/models/llama3_moe/infra/parallelize.py
+++ b/torchtitan/models/llama3_moe/infra/parallelize.py
@@ -10,10 +10,10 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import Replicate, Shard
 from torch.distributed.tensor.parallel import (
     ColwiseParallel,
-    parallelize_module,
     PrepareModuleInput,
     RowwiseParallel,
     SequenceParallel,
+    parallelize_module,
 )
 
 from torchtitan.config import TORCH_DTYPE_MAP
@@ -64,9 +64,7 @@ def parallelize_llama_moe(
     # TODO: TP currently cannot handle uneven seq_len because we set
     #       `use_local_output=True` to use plain Tensors for legacy reasons.
     #       Need to revisit this.
-    assert (
-        job_config.training.seq_len % parallel_dims.seq_len_divisor == 0
-    ), f"""
+    assert job_config.training.seq_len % parallel_dims.seq_len_divisor == 0, f"""
         Sequence length {job_config.training.seq_len} must be divisible by the product of TP degree
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
         """
@@ -152,7 +150,7 @@ def parallelize_llama_moe(
             pp_enabled=parallel_dims.pp_enabled,
             cpu_offload=job_config.training.enable_cpu_offload,
             reshard_after_forward_policy=job_config.parallelism.fsdp_reshard_after_forward,
-            moe_reshard_after_forward==job_config.moe_overrides.moe_reshard_after_forward,
+            moe_reshard_after_forward=job_config.moe_overrides.moe_reshard_after_forward,
             ep_degree=parallel_dims.ep,
             dp_mod_ep_mesh=(
                 world_mesh[tuple(dp_mod_ep_mesh_dim_names)]

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -6,7 +6,7 @@
 
 import math
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -79,16 +79,16 @@ class CustomMetricsProcessor(MetricsProcessor):
             for block_idx, transformer_block in model_part.layers.items():
                 if not transformer_block.moe_enabled:
                     continue
-                moe_metrics[f"moe_entropy/layer_{block_idx}"] = (
-                    self.get_normalized_entropy(transformer_block)
-                )
+                moe_metrics[
+                    f"moe_entropy/layer_{block_idx}"
+                ] = self.get_normalized_entropy(transformer_block)
                 if (
                     n_expert_groups := model_part.model_args.moe_args.n_expert_groups
                 ) > 1:
-                    moe_metrics[f"moe_group_entropy/layer_{block_idx}"] = (
-                        self.get_expert_group_normalized_group_entropy(
-                            transformer_block, n_expert_groups
-                        )
+                    moe_metrics[
+                        f"moe_group_entropy/layer_{block_idx}"
+                    ] = self.get_expert_group_normalized_group_entropy(
+                        transformer_block, n_expert_groups
                     )
                 if isinstance(transformer_block.moe, VirtualGroupMoE):
                     for replica_idx, frac in self.get_replica_routing_fraction(
@@ -105,9 +105,9 @@ class CustomMetricsProcessor(MetricsProcessor):
                 moe_metrics[f"moe_router_weight/layer_{block_idx} abs mean"] = (
                     router_weight.abs().mean().item()
                 )
-                moe_metrics[f"moe_router_weight/layer_{block_idx} std"] = (
-                    router_weight.std().item()
-                )
+                moe_metrics[
+                    f"moe_router_weight/layer_{block_idx} std"
+                ] = router_weight.std().item()
 
         for hook in self.hooks:
             moe_metrics = {**moe_metrics, **hook.get_stats_dict()}

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -6,7 +6,7 @@
 
 import math
 from collections import defaultdict
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
@@ -15,6 +15,7 @@ from torch.distributed.tensor import DTensor
 from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.distributed import ParallelDims
 from torchtitan.models.llama3_moe.custom_args import Llama3MoEJobConfig
+from torchtitan.models.llama3_moe.model.model import VirtualGroupMoE
 from torchtitan.models.moe import MoE
 
 if TYPE_CHECKING:
@@ -78,17 +79,24 @@ class CustomMetricsProcessor(MetricsProcessor):
             for block_idx, transformer_block in model_part.layers.items():
                 if not transformer_block.moe_enabled:
                     continue
-                moe_metrics[
-                    f"moe_entropy/layer_{block_idx}"
-                ] = self.get_normalized_entropy(transformer_block)
+                moe_metrics[f"moe_entropy/layer_{block_idx}"] = (
+                    self.get_normalized_entropy(transformer_block)
+                )
                 if (
                     n_expert_groups := model_part.model_args.moe_args.n_expert_groups
                 ) > 1:
-                    moe_metrics[
-                        f"moe_group_entropy/layer_{block_idx}"
-                    ] = self.get_expert_group_normalized_group_entropy(
-                        transformer_block, n_expert_groups
+                    moe_metrics[f"moe_group_entropy/layer_{block_idx}"] = (
+                        self.get_expert_group_normalized_group_entropy(
+                            transformer_block, n_expert_groups
+                        )
                     )
+                if isinstance(transformer_block.moe, VirtualGroupMoE):
+                    for replica_idx, frac in self.get_replica_routing_fraction(
+                        transformer_block
+                    ).items():
+                        moe_metrics[
+                            f"moe_replica/layer_{block_idx} replica_{replica_idx} frac"
+                        ] = frac
                 # Reset
                 transformer_block.moe.tokens_per_expert_cumulative.zero_()
                 router_weight = transformer_block.moe.router.gate.weight
@@ -97,9 +105,9 @@ class CustomMetricsProcessor(MetricsProcessor):
                 moe_metrics[f"moe_router_weight/layer_{block_idx} abs mean"] = (
                     router_weight.abs().mean().item()
                 )
-                moe_metrics[
-                    f"moe_router_weight/layer_{block_idx} std"
-                ] = router_weight.std().item()
+                moe_metrics[f"moe_router_weight/layer_{block_idx} std"] = (
+                    router_weight.std().item()
+                )
 
         for hook in self.hooks:
             moe_metrics = {**moe_metrics, **hook.get_stats_dict()}
@@ -149,6 +157,24 @@ class CustomMetricsProcessor(MetricsProcessor):
         max_entropy = math.log(tokens_per_expert_group_cumulative_prob.numel())
         normalized_entropy = entropy / max_entropy
         return normalized_entropy
+
+    def get_replica_routing_fraction(
+        self, transformer_block: nn.Module
+    ) -> dict[int, float]:
+        moe = transformer_block.moe
+        if not isinstance(moe, VirtualGroupMoE):
+            raise ValueError(f"{moe=} must be a VirtualGroupMoE instance.")
+        tokens_per_replica_cumulative = (
+            moe.tokens_per_expert_cumulative.reshape(moe.n_replicas, -1).sum(dim=-1)
+            + self.eps
+        )
+        tokens_per_replica_cumulative_prob = (
+            tokens_per_replica_cumulative
+        ) / tokens_per_replica_cumulative.sum()
+        return {
+            idx: frac
+            for idx, frac in enumerate(tokens_per_replica_cumulative_prob.tolist())
+        }
 
     def log(
         self,


### PR DESCRIPTION
Grab bag of small changes and fixes
* Fixes `moe_reshard_after_forward` (#42) so that this option is actually respected
* Adds a `routed_expert_lr` optimizer option for a custom routed expert LR
* Adds more tests.