### PR TITLE
chores: refactors, tests, and metric normalization

### DIFF
--- a/tests/llama3_moe/test_model.py
+++ b/tests/llama3_moe/test_model.py
@@ -8,20 +8,20 @@
 import pytest
 import torch
 import torch.nn.functional as F
-from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.models.llama3_moe import (
+    apply_custom_init,
+    llama3_moe_configs,
     Llama3MoE,
     Llama3MoEJobConfig,
     Llama3MoEModelArgs,
     Llama3MoEStateDictAdapter,
-    apply_custom_init,
-    llama3_moe_configs,
 )
 from torchtitan.models.llama3_moe.metrics import MoEHook
 from torchtitan.models.moe import MoE
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 TEST_TEXT = """
 The biggest lesson that can be read from 70 years of AI research is that general methods that leverage

--- a/tests/llama3_moe/test_model.py
+++ b/tests/llama3_moe/test_model.py
@@ -8,19 +8,20 @@
 import pytest
 import torch
 import torch.nn.functional as F
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.models.llama3_moe import (
-    llama3_moe_configs,
     Llama3MoE,
     Llama3MoEJobConfig,
     Llama3MoEModelArgs,
     Llama3MoEStateDictAdapter,
+    apply_custom_init,
+    llama3_moe_configs,
 )
 from torchtitan.models.llama3_moe.metrics import MoEHook
 from torchtitan.models.moe import MoE
-from transformers import AutoModelForCausalLM, AutoTokenizer
 
 TEST_TEXT = """
 The biggest lesson that can be read from 70 years of AI research is that general methods that leverage
@@ -188,6 +189,28 @@ class TestModel:
             model = Llama3MoE(args)
         moe_enabled_list = [l.moe_enabled for l in model.layers.values()]
         assert moe_enabled_list == [False, True, True, False]
+
+    def test_model_router_init(self):
+        job_config = Llama3MoEJobConfig()
+        job_config.moe_overrides.router_init_std = 1.0
+        args = Llama3MoEModelArgs(
+            dim=self.dim,
+            moe_inter_dim=self.moe_inter_dim,
+            n_layers=self.n_layers,
+            n_heads=self.n_heads,
+            vocab_size=self.vocab_size,
+            is_moe_list=[True for _ in range(self.n_layers)],
+        )
+        args.moe_args.load_balance_coeff = 1e-4
+        args.moe_args.n_expert_groups = 2
+        model = Llama3MoE(args)
+        model.init_weights()
+
+        before_std = model.layers["0"].moe.router.gate.weight.std()
+        apply_custom_init(model, job_config)
+        after_std = model.layers["0"].moe.router.gate.weight.std()
+
+        assert not torch.isclose(before_std, after_std)
 
 
 class TestHooks:

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -27,7 +27,11 @@ from torchtitan.models.llama3_moe.metrics import (
     CustomMetricsProcessor,
 )
 from torchtitan.models.llama3_moe.model.args import Llama3MoEModelArgs, RoPEScalingArgs
-from torchtitan.models.llama3_moe.model.model import Llama3MoE, VirtualGroupMoE, apply_custom_init
+from torchtitan.models.llama3_moe.model.model import (
+    apply_custom_init,
+    Llama3MoE,
+    VirtualGroupMoE,
+)
 from torchtitan.models.llama3_moe.model.state_dict_adapter import (
     Llama3MoEStateDictAdapter,
 )

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -27,7 +27,7 @@ from torchtitan.models.llama3_moe.metrics import (
     CustomMetricsProcessor,
 )
 from torchtitan.models.llama3_moe.model.args import Llama3MoEModelArgs, RoPEScalingArgs
-from torchtitan.models.llama3_moe.model.model import Llama3MoE, VirtualGroupMoE
+from torchtitan.models.llama3_moe.model.model import Llama3MoE, VirtualGroupMoE, apply_custom_init
 from torchtitan.models.llama3_moe.model.state_dict_adapter import (
     Llama3MoEStateDictAdapter,
 )

--- a/torchtitan/models/llama3_moe/__init__.py
+++ b/torchtitan/models/llama3_moe/__init__.py
@@ -42,6 +42,7 @@ from torchtitan.protocols.train_spec import TrainSpec
 __all__ = [
     "CustomCheckpointManager",
     "CustomMetricsProcessor",
+    "apply_custom_init",
     "Llama3MoE",
     "Llama3MoEJobConfig",
     "Llama3MoEModelArgs",

--- a/torchtitan/models/llama3_moe/metrics.py
+++ b/torchtitan/models/llama3_moe/metrics.py
@@ -80,13 +80,13 @@ class CustomMetricsProcessor(MetricsProcessor):
                 if not transformer_block.moe_enabled:
                     continue
                 moe_metrics[
-                    f"moe_entropy/layer_{block_idx}"
+                    f"moe_entropy/layers.{block_idx}"
                 ] = self.get_normalized_entropy(transformer_block)
                 if (
                     n_expert_groups := model_part.model_args.moe_args.n_expert_groups
                 ) > 1:
                     moe_metrics[
-                        f"moe_group_entropy/layer_{block_idx}"
+                        f"moe_group_entropy/layers.{block_idx}"
                     ] = self.get_expert_group_normalized_group_entropy(
                         transformer_block, n_expert_groups
                     )
@@ -95,18 +95,18 @@ class CustomMetricsProcessor(MetricsProcessor):
                         transformer_block
                     ).items():
                         moe_metrics[
-                            f"moe_replica/layer_{block_idx} replica_{replica_idx} frac"
+                            f"moe_replica/layers.{block_idx} replica_{replica_idx} frac"
                         ] = frac
                 # Reset
                 transformer_block.moe.tokens_per_expert_cumulative.zero_()
                 router_weight = transformer_block.moe.router.gate.weight
                 if isinstance(router_weight, DTensor):
                     router_weight = router_weight.full_tensor()
-                moe_metrics[f"moe_router_weight/layer_{block_idx} abs mean"] = (
+                moe_metrics[f"moe_router_weight/layers.{block_idx} abs mean"] = (
                     router_weight.abs().mean().item()
                 )
                 moe_metrics[
-                    f"moe_router_weight/layer_{block_idx} std"
+                    f"moe_router_weight/layers.{block_idx} std"
                 ] = router_weight.std().item()
 
         for hook in self.hooks:

--- a/torchtitan/models/llama3_moe/model/model.py
+++ b/torchtitan/models/llama3_moe/model/model.py
@@ -14,6 +14,7 @@ from einops import rearrange
 from torch import nn
 
 from torchtitan.models.llama3.model.model import Attention, FeedForward
+from torchtitan.models.llama3_moe.custom_args import Llama3MoEJobConfig
 from torchtitan.models.llama3_moe.model.args import Llama3MoEModelArgs, RoPEScalingArgs
 from torchtitan.models.moe import MoE, MoEArgs
 from torchtitan.protocols.train_spec import ModelProtocol
@@ -587,3 +588,24 @@ class Llama3MoE(nn.Module, ModelProtocol):
         h = self.norm(h) if self.norm else h
         output = self.output(h) if self.output else h
         return output
+
+
+@torch.no_grad
+def apply_custom_init(model: Llama3MoE, job_config: Llama3MoEJobConfig) -> None:
+    if not isinstance(model, Llama3MoE):
+        raise ValueError(f"{model=} is not a Llama3MoE instance.")
+    if not isinstance(job_config, Llama3MoEJobConfig):
+        raise ValueError(f"{job_config=} is not a Llama3MoEJobConfig instance")
+    if (
+        job_config.moe_overrides is not None
+        and (std := job_config.moe_overrides.router_init_std) is not None
+    ):
+        logger.info(f"Intializing router weights with {std=}")
+        for maybe_moe in model.modules():
+            if isinstance(maybe_moe, MoE):
+                logger.info(f"Setting {maybe_moe} router gate weight {std=}")
+                nn.init.trunc_normal_(maybe_moe.router.gate.weight, std=std)
+                if hasattr(maybe_moe, "post_init"):
+                    # Ensure that any post-init steps are handled, e.g. for virtual group
+                    # init.
+                    maybe_moe.post_init()

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -11,7 +11,6 @@ from datetime import timedelta
 from typing import Any, Generator, Iterable, Optional
 
 import torch
-import torch.nn as nn
 from torch.distributed.elastic.multiprocessing.errors import record
 
 import torchtitan.protocols.train_spec as train_spec_module

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -14,7 +14,6 @@ import torch
 import torch.nn as nn
 from torch.distributed.elastic.multiprocessing.errors import record
 
-from torchtitan.models.llama3_moe.model.model import apply_custom_init
 import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager, ModelWrapper
 from torchtitan.components.dataloader import DataloaderExhaustedError
@@ -24,18 +23,19 @@ from torchtitan.components.metrics import (
     build_metrics_processor,
     ensure_pp_loss_visible,
 )
-from torchtitan.config import TORCH_DTYPE_MAP, ConfigManager
+from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
 from torchtitan.config.job_config import JobConfig
-from torchtitan.distributed import ParallelDims
-from torchtitan.distributed import utils as dist_utils
+from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.models.attention import init_attention_mask
 from torchtitan.models.llama3_moe import (
     CustomCheckpointManager,
-    TransformingHuggingFaceStorageReader,
     get_hf_weight_transform_cls,
+    TransformingHuggingFaceStorageReader,
 )
 from torchtitan.models.llama3_moe.custom_args import Llama3MoEJobConfig
 from torchtitan.models.llama3_moe.metrics import CustomMetricsProcessor, MoEHook
+
+from torchtitan.models.llama3_moe.model.model import apply_custom_init
 from torchtitan.models.llama3_moe.top_k_scheduler import get_top_k_scheduler
 from torchtitan.models.moe import MoE
 from torchtitan.protocols.model_converter import build_model_converters
@@ -275,7 +275,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 apply_custom_init(m, job_config)
 
                 m.train()
-
 
             # confirm that user will be able to view loss metrics on the console
             ensure_pp_loss_visible(parallel_dims, job_config, color)
@@ -677,8 +676,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 )
 
                 # Run validation if validator is available
-                if self.job_config.validation.enable and self.validator.should_validate(
-                    self.step
+                if (
+                    self.job_config.validation.enable
+                    and self.validator.should_validate(self.step)
                 ):
                     with self.loss_fn.no_rescale():
                         self.validator.validate(self.model_parts, self.step)
@@ -738,12 +738,12 @@ if __name__ == "__main__":
         trainer = Trainer(config)
 
         if config.checkpoint.create_seed_checkpoint:
-            assert int(os.environ["WORLD_SIZE"]) == 1, (
-                "Must create seed checkpoint using a single device, to disable sharding."
-            )
-            assert config.checkpoint.enable, (
-                "Must enable checkpointing when creating a seed checkpoint."
-            )
+            assert (
+                int(os.environ["WORLD_SIZE"]) == 1
+            ), "Must create seed checkpoint using a single device, to disable sharding."
+            assert (
+                config.checkpoint.enable
+            ), "Must enable checkpointing when creating a seed checkpoint."
             trainer.checkpointer.save(curr_step=0, last_step=True)
             logger.info("Created seed checkpoint")
         else:

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -14,6 +14,7 @@ import torch
 import torch.nn as nn
 from torch.distributed.elastic.multiprocessing.errors import record
 
+from torchtitan.models.llama3_moe.model.model import apply_custom_init
 import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager, ModelWrapper
 from torchtitan.components.dataloader import DataloaderExhaustedError
@@ -23,14 +24,15 @@ from torchtitan.components.metrics import (
     build_metrics_processor,
     ensure_pp_loss_visible,
 )
-from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
+from torchtitan.config import TORCH_DTYPE_MAP, ConfigManager
 from torchtitan.config.job_config import JobConfig
-from torchtitan.distributed import ParallelDims, utils as dist_utils
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed import utils as dist_utils
 from torchtitan.models.attention import init_attention_mask
 from torchtitan.models.llama3_moe import (
     CustomCheckpointManager,
-    get_hf_weight_transform_cls,
     TransformingHuggingFaceStorageReader,
+    get_hf_weight_transform_cls,
 )
 from torchtitan.models.llama3_moe.custom_args import Llama3MoEJobConfig
 from torchtitan.models.llama3_moe.metrics import CustomMetricsProcessor, MoEHook
@@ -268,19 +270,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 m.to_empty(device=init_device)
                 with torch.no_grad():
                     m.init_weights(buffer_device=buffer_device)
+
+                # Custom init, e.g. for router std
+                apply_custom_init(m, job_config)
+
                 m.train()
-                if (
-                    moe_overrides is not None
-                    and (std := moe_overrides.router_init_std) is not None
-                ):
-                    logger.info(f"Intializing router weights with {std=}")
-                    for maybe_moe in model.modules():
-                        if isinstance(maybe_moe, MoE):
-                            nn.init.trunc_normal_(maybe_moe.router.gate.weight, std=std)
-                            if hasattr(maybe_moe, "post_init"):
-                                # Ensure that any post-init steps are handled, e.g. for virtual group
-                                # init.
-                                maybe_moe.post_init()
+
 
             # confirm that user will be able to view loss metrics on the console
             ensure_pp_loss_visible(parallel_dims, job_config, color)
@@ -291,18 +286,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             model.to_empty(device=init_device)
             with torch.no_grad():
                 model.init_weights(buffer_device=buffer_device)
-            if (
-                moe_overrides is not None
-                and (std := moe_overrides.router_init_std) is not None
-            ):
-                logger.info(f"Intializing router weights with {std=}")
-                for maybe_moe in model.modules():
-                    if isinstance(maybe_moe, MoE):
-                        nn.init.trunc_normal_(maybe_moe.router.gate.weight, std=std)
-                        if hasattr(maybe_moe, "post_init"):
-                            # Ensure that any post-init steps are handled, e.g. for virtual group
-                            # init.
-                            maybe_moe.post_init()
+            # Custom init, e.g. for router std
+            apply_custom_init(m, job_config)
+
             model.train()
 
             self.model_parts = [model]
@@ -691,9 +677,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 )
 
                 # Run validation if validator is available
-                if (
-                    self.job_config.validation.enable
-                    and self.validator.should_validate(self.step)
+                if self.job_config.validation.enable and self.validator.should_validate(
+                    self.step
                 ):
                     with self.loss_fn.no_rescale():
                         self.validator.validate(self.model_parts, self.step)
@@ -753,12 +738,12 @@ if __name__ == "__main__":
         trainer = Trainer(config)
 
         if config.checkpoint.create_seed_checkpoint:
-            assert (
-                int(os.environ["WORLD_SIZE"]) == 1
-            ), "Must create seed checkpoint using a single device, to disable sharding."
-            assert (
-                config.checkpoint.enable
-            ), "Must enable checkpointing when creating a seed checkpoint."
+            assert int(os.environ["WORLD_SIZE"]) == 1, (
+                "Must create seed checkpoint using a single device, to disable sharding."
+            )
+            assert config.checkpoint.enable, (
+                "Must enable checkpointing when creating a seed checkpoint."
+            )
             trainer.checkpointer.save(curr_step=0, last_step=True)
             logger.info("Created seed checkpoint")
         else:


### PR DESCRIPTION
Stanardized wandb metric names so that we always have a `layers.XXX` string, not a mix of that and `layer_XXX`. Also refactors the custom router init into a common and more general function, and adds some minor tests.