### PR TITLE
zero_lr_steps

### DIFF
--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -104,33 +104,34 @@ def build_lr_schedulers(
         lr_scheduler_config (LRSchedulerConfig): The lr scheduler config.
         training_steps (int): The total number of training steps.
     """
+    zero_lr_steps = int(getattr(lr_scheduler_config, "zero_lr_steps", 0))
     warmup_steps = int(lr_scheduler_config.warmup_steps)
 
-    if warmup_steps > training_steps:
-        logger.warning(
-            f"Warmup steps ({warmup_steps}) exceed total training steps ({training_steps}). "
-            f"Adjusting warmup steps to {training_steps}."
+    if warmup_steps + zero_lr_steps > training_steps:
+        raise ValueError(
+            f"{warmup_steps + zero_lr_steps=} must be smaller than {training_steps=}"
         )
-        warmup_steps = training_steps
+    warmup_zero_steps = warmup_steps + zero_lr_steps
 
     if lr_scheduler_config.decay_ratio is not None:
         decay_steps = round(training_steps * lr_scheduler_config.decay_ratio)
-        if warmup_steps + decay_steps > training_steps:
+        if warmup_zero_steps + decay_steps > training_steps:
             logger.warning(
-                f"Warmup ({warmup_steps}) + decay ({decay_steps}) steps exceed "
+                f"Warmup plus zero ({warmup_zero_steps}) + decay ({decay_steps}) steps exceed "
                 f"total training steps ({training_steps}). "
-                f"Adjusting decay steps to {training_steps - warmup_steps}."
+                f"Adjusting decay steps to {training_steps - warmup_zero_steps}."
             )
-            decay_steps = training_steps - warmup_steps
+            decay_steps = training_steps - warmup_zero_steps
     else:
-        decay_steps = training_steps - warmup_steps
+        decay_steps = training_steps - warmup_zero_steps
     # Add a virtual last step to prevent the learning rate from dropping to 0
-    stable_steps = training_steps + 1 - warmup_steps - decay_steps
+    stable_steps = training_steps + 1 - warmup_zero_steps - decay_steps
     lr_decay_type = lr_scheduler_config.decay_type
     min_lr_factor = lr_scheduler_config.min_lr_factor
 
     def linear_warmup_stable_decay(
         current_step: int,
+        zero_lr_steps: int,
         warmup_steps: int,
         stable_steps: int,
         decay_steps: int,
@@ -154,22 +155,26 @@ def build_lr_schedulers(
         If `min_lr_factor` is specified, the decay range is scaled from 1 to `min_lr_factor`
         to ensure the learning rate does not drop below this minimum value.
         """
-        warmup_stable_steps = warmup_steps + stable_steps
-        if current_step < warmup_steps:
+        warmup_zero_steps = warmup_steps + zero_lr_steps
+        warmup_zero_stable_steps = warmup_zero_steps + stable_steps
+        if current_step < zero_lr_steps:
+            current_step += 1
+            curr_adjustment = 0.0
+        elif current_step < warmup_zero_steps:
             # linear warmup
             # 0-indexed step, hence + 1 adjustments
             current_step += 1
             assert (
                 warmup_steps != 0
             ), "warmup_steps must not be zero to reach this branch"
-            curr_adjustment = float(current_step / warmup_steps)
-        elif current_step < warmup_stable_steps:
+            curr_adjustment = float((current_step - zero_lr_steps) / warmup_steps)
+        elif current_step < warmup_zero_stable_steps:
             curr_adjustment = 1.0
         else:
             # 0-indexed step, hence + 1 adjustments
             current_step += 1
             assert decay_steps != 0, "decay_steps must not be zero to reach this branch"
-            progress = float(current_step - warmup_stable_steps) / decay_steps
+            progress = float(current_step - warmup_zero_stable_steps) / decay_steps
 
             if lr_decay_type == "linear":
                 curr_adjustment = 1 - progress
@@ -186,6 +191,7 @@ def build_lr_schedulers(
 
     lr_lambda = functools.partial(
         linear_warmup_stable_decay,
+        zero_lr_steps=zero_lr_steps,
         warmup_steps=warmup_steps,
         stable_steps=stable_steps,
         decay_steps=decay_steps,

--- a/torchtitan/models/llama3_moe/custom_args.py
+++ b/torchtitan/models/llama3_moe/custom_args.py
@@ -7,7 +7,7 @@
 from dataclasses import dataclass, field
 from typing import Literal
 
-from torchtitan.config.job_config import JobConfig, Optimizer
+from torchtitan.config.job_config import JobConfig, LRScheduler, Optimizer
 
 
 @dataclass
@@ -57,8 +57,8 @@ class MoEOverrides:
     score_before_experts: bool | None = None
     top_k: int | None = None
     use_grouped_mm: bool | None = None
-    load_balance_coeff: float | None | None = None
-    hf_ffn_hidden_dim: int | None | None = None
+    load_balance_coeff: float | None = None
+    hf_ffn_hidden_dim: int | None = None
     n_expert_groups: int | None = None
     top_k_group: int | None = None
     # Custom args
@@ -77,9 +77,15 @@ class Llama3MoEOptimizer(Optimizer):
 
 
 @dataclass
+class Llama3MoELRScheduler(LRScheduler):
+    zero_lr_steps: int = 0
+
+
+@dataclass
 class Llama3MoEJobConfig(JobConfig):
     custom_args: Llama3MoECustomArgs = field(default_factory=Llama3MoECustomArgs)
     top_k_args: TopKSchedulerArgs = field(default_factory=TopKSchedulerArgs)
     model_overrides: ModelOverrides = field(default_factory=ModelOverrides)
     moe_overrides: MoEOverrides = field(default_factory=MoEOverrides)
     optimizer: Llama3MoEOptimizer = field(default_factory=Llama3MoEOptimizer)
+    lr_scheduler: Llama3MoELRScheduler = field(default_factory=Llama3MoELRScheduler)


### PR DESCRIPTION
Adds a `zero_lr_steps` flag for the lr scheduler such that the first steps have strictly zero lr when this cfg is non-trivial.