### PR TITLE
Adding tests

### DIFF
--- a/tests/llama3_moe/test_model.py
+++ b/tests/llama3_moe/test_model.py
@@ -8,20 +8,20 @@
 import pytest
 import torch
 import torch.nn.functional as F
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.models.llama3_moe import (
-    apply_custom_init,
-    llama3_moe_configs,
     Llama3MoE,
     Llama3MoEJobConfig,
     Llama3MoEModelArgs,
     Llama3MoEStateDictAdapter,
+    apply_custom_init,
+    llama3_moe_configs,
 )
 from torchtitan.models.llama3_moe.metrics import MoEHook
 from torchtitan.models.moe import MoE
-from transformers import AutoModelForCausalLM, AutoTokenizer
 
 TEST_TEXT = """
 The biggest lesson that can be read from 70 years of AI research is that general methods that leverage
@@ -212,6 +212,29 @@ class TestModel:
 
         assert not torch.isclose(before_std, after_std)
 
+    def test_model_kv_cache(self):
+        with torch.inference_mode():
+            args = Llama3MoEModelArgs(
+                dim=self.dim,
+                moe_inter_dim=self.moe_inter_dim,
+                n_layers=self.n_layers,
+                n_heads=self.n_heads,
+                vocab_size=self.vocab_size,
+                is_moe_list=None,
+            )
+            model = Llama3MoE(args)
+            model.init_weights()
+            model.to(self.device)
+            # KV-cache for bs=1 only, apparently.
+            inputs = torch.randint(
+                self.vocab_size, size=(1, self.seqlen), device=self.device
+            )
+            inputs_except_last = inputs[:, :-1]
+            inputs_only_last = inputs[:, -1:]
+            _, past_key_values = model(inputs_except_last, past_key_values=[])
+            out_last_only, _ = model(inputs_only_last, past_key_values=past_key_values)
+            out_ref = model(inputs)
+            torch.testing.assert_close(out_ref[:, -1], out_last_only[:, -1])
 
 class TestHooks:
     # Small Defaults

--- a/tests/llama3_moe/test_sdpa.py
+++ b/tests/llama3_moe/test_sdpa.py
@@ -1,0 +1,27 @@
+import pytest
+import torch
+import torch.nn.functional as F
+from torch.nn.attention.bias import causal_lower_right
+
+
+class TestSPDA:
+    def test_sdpa_causal_naive(self) -> None:
+        bs, n_heads, seqlen, dim = 1, 4, 64, 128
+        q = torch.randn(bs, n_heads, 1, dim, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(bs, n_heads, seqlen, dim, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(bs, n_heads, seqlen, dim, device="cuda", dtype=torch.bfloat16)
+        o_causal = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        o_acausal = F.scaled_dot_product_attention(q, k, v, is_causal=False)
+
+        with pytest.raises(AssertionError):
+            torch.testing.assert_close(o_causal, o_acausal)
+
+    def test_sdpa_causal_mask(self) -> None:
+        bs, n_heads, seqlen, dim = 1, 4, 64, 128
+        q = torch.randn(bs, n_heads, 1, dim, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(bs, n_heads, seqlen, dim, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(bs, n_heads, seqlen, dim, device="cuda", dtype=torch.bfloat16)
+        attn_mask = causal_lower_right(1, seqlen)
+        o_masked = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
+        o_acausal = F.scaled_dot_product_attention(q, k, v, is_causal=False)
+        torch.testing.assert_close(o_masked, o_acausal)


### PR DESCRIPTION
Apparently the torch sdpa defaults for uneven sequences is just really odd and assumes that the sequences are aligned from their beginnings, rather than from their ends. Probably a good reason for this that I'm not seeing. But anyway, added some tests to confirm that the KV-cache is working for LLama3MoE (the Llama3 KV cache code looks off, though! the cache is never returned from the full model) and to demonstrate the above behavior. 